### PR TITLE
[#100] Fixed updating IP in the RAM CPU status panel

### DIFF
--- a/plugins/cpu/ram-cpu/src/main/java/net/sf/emustudio/ram/cpu/impl/EmulatorImpl.java
+++ b/plugins/cpu/ram-cpu/src/main/java/net/sf/emustudio/ram/cpu/impl/EmulatorImpl.java
@@ -168,8 +168,8 @@ public class EmulatorImpl extends AbstractCPU {
 
     @Override
     public void reset(int pos) {
-        super.reset(pos);
         IP = pos;
+        super.reset(pos);
         if (context.checkTapes()) {
             loadTape(context.getInput());
         }


### PR DESCRIPTION
IP in the GUI should be now correctly updated.