### PR TITLE
[#104] Fixed problem with garbage remainings 

### DIFF
--- a/plugins/compilers/ramc-ram/src/main/java/net/sf/emustudio/ram/compiler/impl/RAMCompiler.java
+++ b/plugins/compilers/ramc-ram/src/main/java/net/sf/emustudio/ram/compiler/impl/RAMCompiler.java
@@ -120,6 +120,8 @@ public class RAMCompiler extends AbstractCompiler {
 
             notifyInfo("Compile was successful.");
             if (memory != null) {
+                //clear the memory before loading new image
+                memory.clear();
                 compiledProgram.loadIntoMemory(memory);
                 notifyInfo("Compiled file was loaded into operating memory.");
             }


### PR DESCRIPTION
Remaining of previously loaded program were still present after compiling a new program. 

The solution was to adjust the RAMMemoryContextImpl::destroy()  method, and to call it in the compiler before loading a new program.

It is a similar clean-up as in RAMMemoryContextImpl::deserialize() before loading program from a file.