### PR TITLE
[#106] Fixed issue 106

### DIFF
--- a/plugins/compilers/as-ssem/src/main/cup/parser.cup
+++ b/plugins/compilers/as-ssem/src/main/cup/parser.cup
@@ -40,7 +40,7 @@ parser code {:
     public ParserImpl(LexerImpl lex, ComplexSymbolFactory csf, CompilerImpl compiler) {
         super(lex, csf);
         lexer = Objects.requireNonNull(lex);
-        compiler = Objects.requireNonNull(compiler);
+        this.compiler = Objects.requireNonNull(compiler);
     }
 
     @Override

--- a/plugins/compilers/as-ssem/src/main/java/net/sf/emustudio/ssem/assembler/TokenImpl.java
+++ b/plugins/compilers/as-ssem/src/main/java/net/sf/emustudio/ssem/assembler/TokenImpl.java
@@ -69,7 +69,7 @@ public class TokenImpl extends ComplexSymbolFactory.ComplexSymbol implements Tok
 
     @Override
     public int getLength() {
-        return cchar + getName().length();
+        return getName().length();
     }
 
     @Override

--- a/plugins/compilers/as-ssem/src/main/jflex/ssem.jflex
+++ b/plugins/compilers/as-ssem/src/main/jflex/ssem.jflex
@@ -77,6 +77,7 @@ comment = "//"[^\r\n]*
 eol = \r|\n|\r\n
 space = [ \t\f]+
 number = \-?[0-9]+
+inputLetter = [a-zA-Z]
 
 %%
 
@@ -119,6 +120,8 @@ number = \-?[0-9]+
     int num = Integer.parseInt(yytext(), 10);
     return token(NUMBER, Token.LITERAL, (byte)(num & 0xFF));
 }
+
+{inputLetter} { /* do nothing, just continue reading */ }
 
 /* error fallback */
 [^] {


### PR DESCRIPTION
- fixed TokenImpl::getLength() method to return the length of the token
- little fix of the ParserImpl compiler in cup grammar file
- added regular expression 'inputLetter' to jflex specification file; without this the lexical analyzer considered alphabet letters as invalid characters and therefore it could not resolve instructions (reserved words) as they are built of these letters