### PR TITLE
[#117] Fixed unwanted emuStudio termination

### DIFF
--- a/main-module/src/main/java/emustudio/main/Main.java
+++ b/main-module/src/main/java/emustudio/main/Main.java
@@ -89,8 +89,8 @@ public class Main {
             showMainWindow(contextPool, settingsManager, computer);
         } else {
             runAutomation(settingsManager, computer);
+            System.exit(0);
         }
-        System.exit(0);
     }
 
     private static void runAutomation(SettingsManagerImpl settingsManager, Computer computer) {


### PR DESCRIPTION
Problem was with`System.exit()` placed in an incorrect place. It should work now.