### PR TITLE
[#124] Fixed issue 124

### DIFF
--- a/plugins/compilers/raspc-rasp/src/main/jflex/lexer.jflex
+++ b/plugins/compilers/raspc-rasp/src/main/jflex/lexer.jflex
@@ -29,7 +29,8 @@ import java.io.Reader;
 
 /*options for the lexer*/
 
-%class LexerImpl  /*name of lexer class*/
+/*name of lexer class*/
+%class LexerImpl  
 %cup  /*switch to CUP parser generator compatibility*/
 %public  
 %implements LexicalAnalyzer, Symbols /*interfaces that resulting lexer implements*/


### PR DESCRIPTION
The problem was that comment in the `lexer.jflex` was in the same line as definition of the name of lexer class and so the resulting `LexerImpl.java` was stored in directory:

`\plugins\compilers\raspc-rasp\target\generated-sources\jflex\net\sf\emustudio\rasp\compiler\LexerImpl  \*name of lexer class*\LexerImpl.java`

It means that comment was simply not interpreted as a comment. As Windows platform does not support the '*' character in file names, generation of lexer class failed.