### PR TITLE
[#380, #375] simh-pseudo: Fix sign-extension bugs, add missing comman…

### DIFF
--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/GenInterrupt.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/GenInterrupt.java
@@ -9,6 +9,11 @@ public class GenInterrupt implements Command {
     private int genInterruptVec = 0; // stores interrupt vector
 
     @Override
+    public void reset(Control control) {
+        genInterruptPos = 0;
+    }
+
+    @Override
     public void write(byte data, Control control) {
         if (genInterruptPos == 0) {
             genInterruptVec = data; // interrupt vector is not used.

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/GetCPUClockFrequency.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/GetCPUClockFrequency.java
@@ -17,14 +17,26 @@ public class GetCPUClockFrequency implements Command {
     @Override
     public byte read(Control control) {
         byte result;
-        if (getClockFrequencyPos == 0) {
-            cpuFreq.set(control.getCpu().getCPUFrequency());
-            result = (byte) (cpuFreq.get() & 0xff);
-            getClockFrequencyPos = 1;
-        } else {
-            result = (byte) ((cpuFreq.get() >> 8) & 0xff);
-            getClockFrequencyPos = 0;
-            control.clearCommand();
+        switch (getClockFrequencyPos) {
+            case 0:
+                cpuFreq.set(control.getCpu().getCPUFrequency());
+                result = (byte) (cpuFreq.get() & 0xff);
+                getClockFrequencyPos = 1;
+                break;
+            case 1:
+                result = (byte) ((cpuFreq.get() >> 8) & 0xff);
+                getClockFrequencyPos = 2;
+                break;
+            case 2:
+                result = (byte) ((cpuFreq.get() >> 16) & 0xff);
+                getClockFrequencyPos = 3;
+                break;
+            case 3:
+            default:
+                result = (byte) ((cpuFreq.get() >> 24) & 0xff);
+                getClockFrequencyPos = 0;
+                control.clearCommand();
+                break;
         }
         return result;
     }

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/GetHostOSPathSeparator.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/GetHostOSPathSeparator.java
@@ -7,6 +7,7 @@ public class GetHostOSPathSeparator implements Command {
 
     @Override
     public byte read(Control control) {
+        control.clearCommand();
         return (byte) GetHostFilenames.hostPathSeparator;
     }
 

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/ReadStopWatch.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/ReadStopWatch.java
@@ -16,13 +16,25 @@ public class ReadStopWatch implements Command {
     @Override
     public byte read(Control control) {
         byte result;
-        if (getStopWatchDeltaPos == 0) {
-            result = (byte) (stopWatchDelta & 0xff);
-            getStopWatchDeltaPos = 1;
-        } else {
-            result = (byte) ((stopWatchDelta >> 8) & 0xff);
-            getStopWatchDeltaPos = 0;
-            control.clearCommand();
+        switch (getStopWatchDeltaPos) {
+            case 0:
+                result = (byte) (stopWatchDelta & 0xff);
+                getStopWatchDeltaPos = 1;
+                break;
+            case 1:
+                result = (byte) ((stopWatchDelta >> 8) & 0xff);
+                getStopWatchDeltaPos = 2;
+                break;
+            case 2:
+                result = (byte) ((stopWatchDelta >> 16) & 0xff);
+                getStopWatchDeltaPos = 3;
+                break;
+            case 3:
+            default:
+                result = (byte) ((stopWatchDelta >> 24) & 0xff);
+                getStopWatchDeltaPos = 0;
+                control.clearCommand();
+                break;
         }
         return result;
     }

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetBankSelect.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetBankSelect.java
@@ -10,4 +10,9 @@ public class SetBankSelect implements Command {
         control.getMemory().selectBank(data);
         control.clearCommand();
     }
+
+    @Override
+    public void start(Control control) {
+        control.clearReadCommand();
+    }
 }

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetCPUClockFrequency.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetCPUClockFrequency.java
@@ -15,13 +15,25 @@ public class SetCPUClockFrequency implements Command {
 
     @Override
     public void write(byte data, Control control) {
-        if (setClockFrequencyPos == 0) {
-            newClockFrequency = data & 0xFF;
-            setClockFrequencyPos = 1;
-        } else {
-            control.getCpu().setCPUFrequency(((data << 8) & 0xFF00) | newClockFrequency);
-            setClockFrequencyPos = 0;
-            control.clearCommand();
+        switch (setClockFrequencyPos) {
+            case 0:
+                newClockFrequency = data & 0xFF;
+                setClockFrequencyPos = 1;
+                break;
+            case 1:
+                newClockFrequency |= (data & 0xFF) << 8;
+                setClockFrequencyPos = 2;
+                break;
+            case 2:
+                newClockFrequency |= (data & 0xFF) << 16;
+                setClockFrequencyPos = 3;
+                break;
+            case 3:
+                newClockFrequency |= (data & 0xFF) << 24;
+                control.getCpu().setCPUFrequency(newClockFrequency);
+                setClockFrequencyPos = 0;
+                control.clearCommand();
+                break;
         }
     }
 

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetClockCPM3.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetClockCPM3.java
@@ -26,10 +26,10 @@ public class SetClockCPM3 implements Command {
     @Override
     public void write(byte data, Control control) {
         if (setClockCPM3Pos == 0) {
-            setClockCPM3Adr = data;
+            setClockCPM3Adr = data & 0xFF;
             setClockCPM3Pos = 1;
         } else {
-            setClockCPM3Adr |= (data << 8);
+            setClockCPM3Adr |= ((data & 0xFF) << 8);
             setClockCPM3(control.getMemory());
             setClockCPM3Pos = 0;
             control.clearCommand();

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetClockZSDOS.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetClockZSDOS.java
@@ -24,10 +24,10 @@ public class SetClockZSDOS implements Command {
     @Override
     public void write(byte data, Control control) {
         if (setClockZSDOSPos == 0) {
-            setClockZSDOSAdr = data;
+            setClockZSDOSAdr = data & 0xFF;
             setClockZSDOSPos = 1;
         } else {
-            setClockZSDOSAdr |= (data << 8);
+            setClockZSDOSAdr |= ((data & 0xFF) << 8);
             setClockZSDOS(control.getMemory());
             setClockZSDOSPos = 0;
             control.clearCommand();

--- a/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetTimerInterruptAdr.java
+++ b/plugins/device/simh-pseudo/src/main/java/net/emustudio/plugins/device/simh/commands/SetTimerInterruptAdr.java
@@ -15,10 +15,10 @@ public class SetTimerInterruptAdr implements Command {
     @Override
     public void write(byte data, Control control) {
         if (setTimerInterruptAdrPos == 0) {
-            timerInterruptHandler = data;
+            timerInterruptHandler = data & 0xFF;
             setTimerInterruptAdrPos = 1;
         } else {
-            timerInterruptHandler |= (data << 8);
+            timerInterruptHandler |= ((data & 0xFF) << 8);
             setTimerInterruptAdrPos = 0;
             control.clearCommand();
         }

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/CommandsTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/CommandsTest.java
@@ -1,0 +1,50 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CommandsTest {
+
+    @Test
+    public void testFromIntReturnsCorrectCommand() {
+        assertEquals(Commands.printTimeCmd, Commands.fromInt(0));
+        assertEquals(Commands.startTimerCmd, Commands.fromInt(1));
+        assertEquals(Commands.stopTimerCmd, Commands.fromInt(2));
+        assertEquals(Commands.getSIMHVersionCmd, Commands.fromInt(6));
+        assertEquals(Commands.genInterruptCmd, Commands.fromInt(33));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testFromIntThrowsForInvalidValue() {
+        Commands.fromInt(999);
+    }
+
+    @Test
+    public void testAllCommandsHaveMappings() {
+        for (Commands cmd : Commands.values()) {
+            if (cmd != Commands.unknownCmd) {
+                assertTrue(
+                        "Command " + cmd.name() + " (ordinal=" + cmd.ordinal() + ") should have a mapping",
+                        Commands.COMMANDS_MAP.containsKey(cmd.ordinal())
+                );
+            }
+        }
+    }
+
+    @Test
+    public void testUnknownCommandDoesNotHaveMapping() {
+        assertFalse(Commands.COMMANDS_MAP.containsKey(Commands.unknownCmd.ordinal()));
+    }
+
+    @Test
+    public void testCommandOrdinalsAreSequential() {
+        Commands[] values = Commands.values();
+        for (int i = 0; i < values.length; i++) {
+            assertEquals(i, values[i].ordinal());
+        }
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/PseudoContextTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/PseudoContextTest.java
@@ -1,0 +1,228 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh;
+
+import net.emustudio.plugins.cpu.intel8080.api.Context8080;
+import net.emustudio.plugins.memory.bytemem.api.ByteMemoryContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class PseudoContextTest {
+    private PseudoContext context;
+    private Context8080 cpu;
+    private ByteMemoryContext memory;
+
+    @Before
+    public void setUp() {
+        cpu = createNiceMock(Context8080.class);
+        memory = createNiceMock(ByteMemoryContext.class);
+
+        context = new PseudoContext();
+        context.setCpu(cpu);
+        context.setMemory(memory);
+        context.reset();
+    }
+
+    @Test
+    public void testGetName() {
+        assertNotNull(context.getName());
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("SIMH-pseudo context", context.toString());
+    }
+
+    @Test
+    public void testUnknownCommandIsIgnored() {
+        replay(cpu, memory);
+        // Write an unknown command (e.g., 255)
+        context.write(0xFE, (byte) 0xFF);
+        // Should not throw, just ignore
+    }
+
+    // Test command dispatch: write a known command, then read result
+
+    @Test
+    public void testGetSimhVersionCommand() {
+        replay(cpu, memory);
+
+        // Send getSimhVersion command (ordinal = 6)
+        context.write(0xFE, (byte) Commands.getSIMHVersionCmd.ordinal());
+
+        // Read version string
+        StringBuilder version = new StringBuilder();
+        byte b;
+        while ((b = context.read(0xFE)) != 0) {
+            version.append((char) b);
+        }
+        assertEquals("SIMH004", version.toString());
+    }
+
+    @Test
+    public void testGetBankSelectCommand() {
+        expect(memory.getSelectedBank()).andReturn(2);
+        replay(cpu, memory);
+
+        // Send getBankSelect command (ordinal = 11)
+        context.write(0xFE, (byte) Commands.getBankSelectCmd.ordinal());
+
+        byte result = context.read(0xFE);
+        assertEquals(2, result);
+
+        verify(memory);
+    }
+
+    @Test
+    public void testSetBankSelectCommand() {
+        memory.selectBank(3);
+        expectLastCall();
+        replay(cpu, memory);
+
+        // Send setBankSelect command (ordinal = 12)
+        context.write(0xFE, (byte) Commands.setBankSelectCmd.ordinal());
+        // Write the bank number
+        context.write(0xFE, (byte) 3);
+
+        verify(memory);
+    }
+
+    @Test
+    public void testHasBankedMemoryCommand() {
+        expect(memory.getBanksCount()).andReturn(4);
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.hasBankedMemoryCmd.ordinal());
+
+        byte result = context.read(0xFE);
+        assertEquals(4, result);
+
+        verify(memory);
+    }
+
+    @Test
+    public void testGetCommonCommand() {
+        int boundary = 0xC000;
+        expect(memory.getCommonBoundary()).andReturn(boundary).anyTimes();
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.getCommonCmd.ordinal());
+
+        byte low = context.read(0xFE);
+        byte high = context.read(0xFE);
+
+        int result = (low & 0xFF) | ((high & 0xFF) << 8);
+        assertEquals(boundary, result);
+
+        verify(memory);
+    }
+
+    @Test
+    public void testGetCPUClockFrequencyCommand() {
+        int frequency = 2000;
+        expect(cpu.getCPUFrequency()).andReturn(frequency).anyTimes();
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.getCPUClockFrequency.ordinal());
+
+        byte b0 = context.read(0xFE);
+        byte b1 = context.read(0xFE);
+        byte b2 = context.read(0xFE);
+        byte b3 = context.read(0xFE);
+
+        int result = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
+        assertEquals(frequency, result);
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testSetCPUClockFrequencyCommand() {
+        int frequency = 4000;
+
+        cpu.setCPUFrequency(frequency);
+        expectLastCall();
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.setCPUClockFrequency.ordinal());
+        context.write(0xFE, (byte) (frequency & 0xFF));
+        context.write(0xFE, (byte) ((frequency >> 8) & 0xFF));
+        context.write(0xFE, (byte) ((frequency >> 16) & 0xFF));
+        context.write(0xFE, (byte) ((frequency >> 24) & 0xFF));
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testGetHostOSPathSeparatorCommand() {
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.getHostOSPathSeparatorCmd.ordinal());
+
+        byte result = context.read(0xFE);
+        assertEquals((byte) File.separatorChar, result);
+    }
+
+    @Test
+    public void testPrintTimeCommand() {
+        replay(cpu, memory);
+
+        // Should not throw
+        context.write(0xFE, (byte) Commands.printTimeCmd.ordinal());
+    }
+
+    @Test
+    public void testResetSIMHInterfaceCommand() {
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.resetSIMHInterfaceCmd.ordinal());
+        // Should not throw
+    }
+
+    @Test
+    public void testResetClearsAllCommandState() {
+        replay(cpu, memory);
+
+        // Send a command that requires parameters
+        context.write(0xFE, (byte) Commands.setTimerDeltaCmd.ordinal());
+        // Don't send all parameters, then reset
+        context.write(0xFE, (byte) 0x10); // first byte of timerDelta only
+
+        context.reset();
+
+        // After reset, should accept new commands normally
+        // Send printTime (simple command)
+        context.write(0xFE, (byte) Commands.printTimeCmd.ordinal());
+        // Should not throw
+    }
+
+    @Test
+    public void testGenInterruptCommand() {
+        byte interruptData = (byte) 0xCF;
+
+        cpu.signalInterrupt(aryEq(new byte[]{interruptData}));
+        expectLastCall();
+        replay(cpu, memory);
+
+        context.write(0xFE, (byte) Commands.genInterruptCmd.ordinal());
+        context.write(0xFE, (byte) 0); // interrupt vector
+        context.write(0xFE, interruptData); // data bus value
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testReadFromUnknownCommandReturnsZero() {
+        replay(cpu, memory);
+
+        // Read without writing a valid command
+        byte result = context.read(0xFE);
+        assertEquals(0, result);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/AttachPTPTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/AttachPTPTest.java
@@ -1,0 +1,33 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AttachPTPTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        AttachPTP.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+        assertFalse(isCommandCleared());
+    }
+
+    @Test
+    public void testReadReturnsLastCPMStatus() {
+        AttachPTP.INS.reset(control);
+        byte result = AttachPTP.INS.read(control);
+        assertEquals(0, result);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testResetClearsStatus() {
+        AttachPTP.INS.reset(control);
+        byte result = AttachPTP.INS.read(control);
+        assertEquals(0, result);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/AttachPTRTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/AttachPTRTest.java
@@ -1,0 +1,25 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AttachPTRTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        AttachPTR.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+        assertFalse(isCommandCleared());
+    }
+
+    @Test
+    public void testReadReturnsZeroByDefault() {
+        AttachPTR.INS.reset(control);
+        byte result = AttachPTR.INS.read(control);
+        assertEquals(0, result);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/CommandTestBase.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/CommandTestBase.java
@@ -1,0 +1,78 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import net.emustudio.plugins.cpu.intel8080.api.Context8080;
+import net.emustudio.plugins.memory.bytemem.api.ByteMemoryContext;
+import org.junit.Before;
+
+import static org.easymock.EasyMock.*;
+
+/**
+ * Base class for command unit tests providing mock infrastructure.
+ */
+public abstract class CommandTestBase {
+    protected Command.Control control;
+    protected Context8080 cpu;
+    protected ByteMemoryContext memory;
+
+    private boolean commandCleared;
+    private boolean readCommandCleared;
+    private boolean writeCommandCleared;
+
+    @Before
+    public void setUpBase() {
+        cpu = createNiceMock(Context8080.class);
+        memory = createNiceMock(ByteMemoryContext.class);
+
+        commandCleared = false;
+        readCommandCleared = false;
+        writeCommandCleared = false;
+
+        control = new Command.Control() {
+            @Override
+            public void clearCommand() {
+                commandCleared = true;
+            }
+
+            @Override
+            public void clearReadCommand() {
+                readCommandCleared = true;
+            }
+
+            @Override
+            public void clearWriteCommand() {
+                writeCommandCleared = true;
+            }
+
+            @Override
+            public ByteMemoryContext getMemory() {
+                return memory;
+            }
+
+            @Override
+            public Context8080 getCpu() {
+                return cpu;
+            }
+        };
+    }
+
+    protected boolean isCommandCleared() {
+        return commandCleared;
+    }
+
+    protected boolean isReadCommandCleared() {
+        return readCommandCleared;
+    }
+
+    protected boolean isWriteCommandCleared() {
+        return writeCommandCleared;
+    }
+
+    protected void resetClearFlags() {
+        commandCleared = false;
+        readCommandCleared = false;
+        writeCommandCleared = false;
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/DetachPTPTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/DetachPTPTest.java
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DetachPTPTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        DetachPTP.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/DetachPTRTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/DetachPTRTest.java
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DetachPTRTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        DetachPTR.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GenInterruptTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GenInterruptTest.java
@@ -1,0 +1,63 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class GenInterruptTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        GenInterrupt.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsReadCommand() {
+        GenInterrupt.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWriteTwoBytesGeneratesInterrupt() {
+        byte interruptData = (byte) 0xCF; // RST 1
+
+        cpu.signalInterrupt(aryEq(new byte[]{interruptData}));
+        expectLastCall();
+        replay(cpu);
+
+        GenInterrupt.INS.start(control);
+        resetClearFlags();
+
+        // First byte: interrupt vector
+        GenInterrupt.INS.write((byte) 0, control);
+        assertFalse(isCommandCleared());
+
+        // Second byte: data to put on data bus
+        GenInterrupt.INS.write(interruptData, control);
+        assertTrue(isCommandCleared());
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        GenInterrupt.INS.start(control);
+        GenInterrupt.INS.write((byte) 1, control); // write first byte
+
+        GenInterrupt.INS.reset(control);
+
+        replay(cpu);
+
+        GenInterrupt.INS.start(control);
+        resetClearFlags();
+
+        // Should be back at position 0, expecting vector byte
+        GenInterrupt.INS.write((byte) 2, control);
+        assertFalse(isCommandCleared()); // still expecting data byte
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetBankSelectTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetBankSelectTest.java
@@ -1,0 +1,48 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class GetBankSelectTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetBankSelect.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturnsSelectedBank() {
+        expect(memory.getSelectedBank()).andReturn(3);
+        replay(memory);
+
+        GetBankSelect.INS.start(control);
+        resetClearFlags();
+
+        byte result = GetBankSelect.INS.read(control);
+        assertEquals(3, result);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+
+    @Test
+    public void testReturnsBank0ByDefault() {
+        expect(memory.getSelectedBank()).andReturn(0);
+        replay(memory);
+
+        GetBankSelect.INS.start(control);
+        resetClearFlags();
+
+        byte result = GetBankSelect.INS.read(control);
+        assertEquals(0, result);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetCPUClockFrequencyTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetCPUClockFrequencyTest.java
@@ -1,0 +1,89 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class GetCPUClockFrequencyTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        GetCPUClockFrequency.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetCPUClockFrequency.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturns4ByteFrequency() {
+        int frequency = 2000; // 2000 kHz
+
+        expect(cpu.getCPUFrequency()).andReturn(frequency).anyTimes();
+        replay(cpu);
+
+        GetCPUClockFrequency.INS.start(control);
+        resetClearFlags();
+
+        // Read 4 bytes (32-bit little-endian)
+        byte b0 = GetCPUClockFrequency.INS.read(control);
+        assertFalse(isCommandCleared());
+        byte b1 = GetCPUClockFrequency.INS.read(control);
+        assertFalse(isCommandCleared());
+        byte b2 = GetCPUClockFrequency.INS.read(control);
+        assertFalse(isCommandCleared());
+        byte b3 = GetCPUClockFrequency.INS.read(control);
+        assertTrue(isCommandCleared());
+
+        int result = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
+        assertEquals(frequency, result);
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testReturnsLargeFrequency() {
+        int frequency = 0x00ABCDEF;
+
+        expect(cpu.getCPUFrequency()).andReturn(frequency).anyTimes();
+        replay(cpu);
+
+        GetCPUClockFrequency.INS.start(control);
+
+        byte b0 = GetCPUClockFrequency.INS.read(control);
+        byte b1 = GetCPUClockFrequency.INS.read(control);
+        byte b2 = GetCPUClockFrequency.INS.read(control);
+        byte b3 = GetCPUClockFrequency.INS.read(control);
+
+        int result = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
+        assertEquals(frequency, result);
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        expect(cpu.getCPUFrequency()).andReturn(2000).anyTimes();
+        replay(cpu);
+
+        GetCPUClockFrequency.INS.start(control);
+        GetCPUClockFrequency.INS.read(control); // read byte 0
+        GetCPUClockFrequency.INS.read(control); // read byte 1
+
+        GetCPUClockFrequency.INS.reset(control);
+        GetCPUClockFrequency.INS.start(control);
+        resetClearFlags();
+
+        // Should start from byte 0 again
+        byte b0 = GetCPUClockFrequency.INS.read(control);
+        assertFalse(isCommandCleared());
+        assertEquals((byte) (2000 & 0xFF), b0);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetClockCPM3Test.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetClockCPM3Test.java
@@ -1,0 +1,53 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GetClockCPM3Test extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetClockCPM3.INS.reset(control);
+        GetClockCPM3.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetClockCPM3.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturns5Bytes() {
+        GetClockCPM3.INS.start(control);
+        resetClearFlags();
+
+        // Read 5 bytes: days_low, days_high, HH, MM, SS
+        for (int i = 0; i < 4; i++) {
+            GetClockCPM3.INS.read(control);
+            assertFalse("Command should not be cleared after byte " + i, isCommandCleared());
+        }
+        // 5th byte should clear command
+        GetClockCPM3.INS.read(control);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testResetClearsState() {
+        GetClockCPM3.INS.start(control);
+        GetClockCPM3.INS.read(control); // read first byte
+
+        GetClockCPM3.INS.reset(control);
+
+        // After reset, reading without start should return 0 and clear command
+        resetClearFlags();
+        byte result = GetClockCPM3.INS.read(control);
+        assertEquals(0, result);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetClockZSDOSTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetClockZSDOSTest.java
@@ -1,0 +1,54 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class GetClockZSDOSTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetClockZSDOS.INS.reset(control);
+        GetClockZSDOS.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetClockZSDOS.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturns6Bytes() {
+        GetClockZSDOS.INS.start(control);
+        resetClearFlags();
+
+        // Read 6 bytes: YY MM DD HH MM SS (BCD)
+        for (int i = 0; i < 5; i++) {
+            GetClockZSDOS.INS.read(control);
+            assertFalse("Command should not be cleared after byte " + i, isCommandCleared());
+        }
+        // 6th byte should clear command
+        GetClockZSDOS.INS.read(control);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testResetClearsState() {
+        GetClockZSDOS.INS.start(control);
+        GetClockZSDOS.INS.read(control); // read first byte
+
+        GetClockZSDOS.INS.reset(control);
+
+        // After reset, reading without start should return 0 and clear command
+        resetClearFlags();
+        byte result = GetClockZSDOS.INS.read(control);
+        assertEquals(0, result);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetCommonTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetCommonTest.java
@@ -1,0 +1,63 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class GetCommonTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetCommon.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturns16BitCommonBoundary() {
+        int boundary = 0xC000; // typical common boundary
+
+        expect(memory.getCommonBoundary()).andReturn(boundary).anyTimes();
+        replay(memory);
+
+        GetCommon.INS.start(control);
+        resetClearFlags();
+
+        // First byte - low
+        byte low = GetCommon.INS.read(control);
+        assertEquals((byte) (boundary & 0xFF), low);
+        assertFalse(isCommandCleared());
+
+        // Second byte - high
+        byte high = GetCommon.INS.read(control);
+        assertEquals((byte) ((boundary >> 8) & 0xFF), high);
+        assertTrue(isCommandCleared());
+
+        // Reconstruct the value
+        int result = (low & 0xFF) | ((high & 0xFF) << 8);
+        assertEquals(boundary, result);
+
+        verify(memory);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        expect(memory.getCommonBoundary()).andReturn(0xC000).anyTimes();
+        replay(memory);
+
+        GetCommon.INS.start(control);
+        GetCommon.INS.read(control); // Read first byte
+
+        GetCommon.INS.reset(control);
+        GetCommon.INS.start(control);
+        resetClearFlags();
+
+        // Should read low byte again (not high)
+        byte low = GetCommon.INS.read(control);
+        assertEquals((byte) 0x00, low);
+        assertFalse(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetHostOSPathSeparatorTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetHostOSPathSeparatorTest.java
@@ -1,0 +1,29 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class GetHostOSPathSeparatorTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetHostOSPathSeparator.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturnsPathSeparatorAndClearsCommand() {
+        GetHostOSPathSeparator.INS.start(control);
+        resetClearFlags();
+
+        byte result = GetHostOSPathSeparator.INS.read(control);
+        assertEquals((byte) File.separatorChar, result);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetSimhVersionTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/GetSimhVersionTest.java
@@ -1,0 +1,56 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GetSimhVersionTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        GetSimhVersion.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+        assertFalse(isCommandCleared());
+    }
+
+    @Test
+    public void testReturnsVersionString() {
+        GetSimhVersion.INS.start(control);
+
+        StringBuilder version = new StringBuilder();
+        byte b;
+        while ((b = GetSimhVersion.INS.read(control)) != 0) {
+            version.append((char) b);
+        }
+        assertEquals("SIMH004", version.toString());
+    }
+
+    @Test
+    public void testClearsCommandAfterLastByte() {
+        GetSimhVersion.INS.start(control);
+        resetClearFlags();
+
+        // Read all bytes until null terminator
+        while (GetSimhVersion.INS.read(control) != 0) {
+            // keep reading
+        }
+        // After reading null terminator, command should be cleared
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        GetSimhVersion.INS.start(control);
+        GetSimhVersion.INS.read(control); // read 'S'
+        GetSimhVersion.INS.read(control); // read 'I'
+
+        GetSimhVersion.INS.reset(control);
+        GetSimhVersion.INS.start(control);
+
+        byte first = GetSimhVersion.INS.read(control);
+        assertEquals('S', (char) first);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/HasBankedMemoryTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/HasBankedMemoryTest.java
@@ -1,0 +1,48 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class HasBankedMemoryTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        HasBankedMemory.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturnsBanksCount() {
+        expect(memory.getBanksCount()).andReturn(4);
+        replay(memory);
+
+        HasBankedMemory.INS.start(control);
+        resetClearFlags();
+
+        byte result = HasBankedMemory.INS.read(control);
+        assertEquals(4, result);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+
+    @Test
+    public void testReturnsSingleBank() {
+        expect(memory.getBanksCount()).andReturn(1);
+        replay(memory);
+
+        HasBankedMemory.INS.start(control);
+        resetClearFlags();
+
+        byte result = HasBankedMemory.INS.read(control);
+        assertEquals(1, result);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/PrintTimeTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/PrintTimeTest.java
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PrintTimeTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        PrintTime.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ReadStopWatchTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ReadStopWatchTest.java
@@ -1,0 +1,79 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ReadStopWatchTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        ReadStopWatch.INS.reset(control);
+        ReadStopWatch.INS.stopWatchNow = 0;
+    }
+
+    @Test
+    public void testStartClearsWriteCommand() {
+        ReadStopWatch.INS.start(control);
+        assertTrue(isWriteCommandCleared());
+    }
+
+    @Test
+    public void testReturns4ByteDelta() {
+        // Set up known delta
+        ReadStopWatch.INS.stopWatchNow = System.currentTimeMillis() - 1000; // 1 second ago
+        ReadStopWatch.INS.start(control);
+        resetClearFlags();
+
+        // Read 4 bytes (32-bit value)
+        ReadStopWatch.INS.read(control);
+        assertFalse(isCommandCleared());
+        ReadStopWatch.INS.read(control);
+        assertFalse(isCommandCleared());
+        ReadStopWatch.INS.read(control);
+        assertFalse(isCommandCleared());
+        ReadStopWatch.INS.read(control);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testReturnsCorrectDeltaValue() {
+        long expectedDelta = 0x12345678L;
+        // Set stopWatchNow so that delta = current - now = expectedDelta
+        long fakeNow = System.currentTimeMillis();
+        ReadStopWatch.INS.stopWatchNow = fakeNow - expectedDelta;
+
+        // Manually compute the delta at start time
+        ReadStopWatch.INS.start(control);
+        resetClearFlags();
+
+        byte b0 = ReadStopWatch.INS.read(control);
+        byte b1 = ReadStopWatch.INS.read(control);
+        byte b2 = ReadStopWatch.INS.read(control);
+        byte b3 = ReadStopWatch.INS.read(control);
+
+        long result = (b0 & 0xFFL) | ((b1 & 0xFFL) << 8) | ((b2 & 0xFFL) << 16) | ((b3 & 0xFFL) << 24);
+        // Allow some tolerance for timing
+        assertTrue("Expected delta around " + expectedDelta + " but got " + result,
+                Math.abs(result - expectedDelta) < 100);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        ReadStopWatch.INS.stopWatchNow = System.currentTimeMillis();
+        ReadStopWatch.INS.start(control);
+        ReadStopWatch.INS.read(control); // read first byte
+
+        ReadStopWatch.INS.reset(control);
+        ReadStopWatch.INS.start(control);
+        resetClearFlags();
+
+        // Should start from byte 0 again
+        ReadStopWatch.INS.read(control);
+        assertFalse(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ReadURLTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ReadURLTest.java
@@ -1,0 +1,59 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ReadURLTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        ReadURL.INS.reset(control);
+    }
+
+    @Test
+    public void testStartResetsState() {
+        ReadURL.INS.start(control);
+        // After start, reading should return 0 (not in read phase)
+        byte result = ReadURL.INS.read(control);
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testResetResetsState() {
+        ReadURL.INS.reset(control);
+        byte result = ReadURL.INS.read(control);
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testWriteNullTerminatorTriggersURLRead() {
+        ReadURL.INS.start(control);
+
+        // Write URL characters (invalid URL to test error handling)
+        ReadURL.INS.write((byte) 'x', control);
+        // Write null terminator to finish URL
+        ReadURL.INS.write((byte) 0, control);
+
+        // Now we're in read phase. First read returns availability (1 or 0)
+        byte avail = ReadURL.INS.read(control);
+        // Should have some content (error message at minimum)
+        assertEquals(1, avail);
+    }
+
+    @Test
+    public void testWriteInReadPhaseClearsCommand() {
+        ReadURL.INS.start(control);
+        ReadURL.INS.write((byte) 'x', control);
+        ReadURL.INS.write((byte) 0, control); // trigger read
+
+        resetClearFlags();
+        // Writing when in read phase should clear command
+        ReadURL.INS.write((byte) 'a', control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ResetPTRTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ResetPTRTest.java
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ResetPTRTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        ResetPTR.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ResetSimhInterfaceTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ResetSimhInterfaceTest.java
@@ -1,0 +1,33 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ResetSimhInterfaceTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        StartTimer.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsCommand() {
+        ResetSimhInterface.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testStartResetsTimerStack() {
+        StartTimer.INS.start(control);
+        StartTimer.INS.start(control);
+        assertEquals(2, StartTimer.INS.markTimeSP);
+
+        ResetSimhInterface.INS.start(control);
+        assertEquals(0, StartTimer.INS.markTimeSP);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ResetStopWatchTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ResetStopWatchTest.java
@@ -1,0 +1,28 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ResetStopWatchTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        ReadStopWatch.INS.reset(control);
+    }
+
+    @Test
+    public void testStartSetsStopWatchNow() {
+        long before = System.currentTimeMillis();
+        ResetStopWatch.INS.start(control);
+        long after = System.currentTimeMillis();
+
+        assertTrue(ReadStopWatch.INS.stopWatchNow >= before);
+        assertTrue(ReadStopWatch.INS.stopWatchNow <= after);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SIMHSleepTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SIMHSleepTest.java
@@ -1,0 +1,25 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SIMHSleepTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        SIMHSleep.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testDoesNotSleepWhenTimerInterruptsActive() {
+        // When timer interrupts are active, sleep should be very fast (skip sleep)
+        // We can't easily test this without more complex setup, but we can verify it doesn't hang
+        SIMHSleep.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/Set8080CPUTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/Set8080CPUTest.java
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class Set8080CPUTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        Set8080CPU.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetBankSelectTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetBankSelectTest.java
@@ -1,0 +1,33 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class SetBankSelectTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsReadCommand() {
+        SetBankSelect.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWriteSelectsBank() {
+        memory.selectBank(5);
+        expectLastCall();
+        replay(memory);
+
+        SetBankSelect.INS.start(control);
+        resetClearFlags();
+
+        SetBankSelect.INS.write((byte) 5, control);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetCPUClockFrequencyTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetCPUClockFrequencyTest.java
@@ -1,0 +1,81 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class SetCPUClockFrequencyTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetCPUClockFrequency.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsReadCommand() {
+        SetCPUClockFrequency.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWrite4ByteFrequency() {
+        int frequency = 4000; // 4000 kHz
+
+        cpu.setCPUFrequency(frequency);
+        expectLastCall();
+        replay(cpu);
+
+        SetCPUClockFrequency.INS.start(control);
+        resetClearFlags();
+
+        // Write 4 bytes (32-bit little-endian)
+        SetCPUClockFrequency.INS.write((byte) (frequency & 0xFF), control);
+        assertFalse(isCommandCleared());
+        SetCPUClockFrequency.INS.write((byte) ((frequency >> 8) & 0xFF), control);
+        assertFalse(isCommandCleared());
+        SetCPUClockFrequency.INS.write((byte) ((frequency >> 16) & 0xFF), control);
+        assertFalse(isCommandCleared());
+        SetCPUClockFrequency.INS.write((byte) ((frequency >> 24) & 0xFF), control);
+        assertTrue(isCommandCleared());
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testWriteLargeFrequency() {
+        int frequency = 0x00ABCDEF;
+
+        cpu.setCPUFrequency(frequency);
+        expectLastCall();
+        replay(cpu);
+
+        SetCPUClockFrequency.INS.start(control);
+        resetClearFlags();
+
+        SetCPUClockFrequency.INS.write((byte) (frequency & 0xFF), control);
+        SetCPUClockFrequency.INS.write((byte) ((frequency >> 8) & 0xFF), control);
+        SetCPUClockFrequency.INS.write((byte) ((frequency >> 16) & 0xFF), control);
+        SetCPUClockFrequency.INS.write((byte) ((frequency >> 24) & 0xFF), control);
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        SetCPUClockFrequency.INS.start(control);
+        SetCPUClockFrequency.INS.write((byte) 0x01, control);
+
+        SetCPUClockFrequency.INS.reset(control);
+        SetCPUClockFrequency.INS.start(control);
+        resetClearFlags();
+
+        // Should accept low byte again
+        SetCPUClockFrequency.INS.write((byte) 0x10, control);
+        assertFalse(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetClockCPM3Test.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetClockCPM3Test.java
@@ -1,0 +1,59 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static net.emustudio.emulib.runtime.helpers.NumberUtils.bin2bcd;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class SetClockCPM3Test extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetClockCPM3.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsReadCommand() {
+        SetClockCPM3.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWriteTwoByteAddress() {
+        int address = 0x2000;
+
+        // Set up memory: 5-byte block: days_low, days_high, HH(BCD), MM(BCD), SS(BCD)
+        // Days since 31 Dec 1977 = e.g. 100 days = 0x0064
+        expect(memory.read(address)).andReturn((byte) 0x64).anyTimes();      // days low
+        expect(memory.read(address + 1)).andReturn((byte) 0x00).anyTimes();  // days high
+        expect(memory.read(address + 2)).andReturn((byte) bin2bcd(10)).anyTimes();  // 10:00:00
+        expect(memory.read(address + 3)).andReturn((byte) bin2bcd(0)).anyTimes();
+        expect(memory.read(address + 4)).andReturn((byte) bin2bcd(0)).anyTimes();
+        replay(memory);
+
+        SetClockCPM3.INS.start(control);
+        resetClearFlags();
+
+        // Write low byte of address
+        SetClockCPM3.INS.write((byte) (address & 0xFF), control);
+        assertFalse(isCommandCleared());
+
+        // Write high byte of address
+        SetClockCPM3.INS.write((byte) ((address >> 8) & 0xFF), control);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+
+    @Test
+    public void testResetClearsDelta() {
+        SetClockCPM3.INS.ClockCPM3Delta = 100;
+        SetClockCPM3.INS.reset(control);
+        assertEquals(0, SetClockCPM3.INS.ClockCPM3Delta);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetClockZSDOSTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetClockZSDOSTest.java
@@ -1,0 +1,62 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static net.emustudio.emulib.runtime.helpers.NumberUtils.bin2bcd;
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class SetClockZSDOSTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetClockZSDOS.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsReadCommand() {
+        SetClockZSDOS.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWriteTwoByteAddress() {
+        // Address is sent as 2 bytes (low, high)
+        // The address points to a 6-byte BCD block: YY MM DD HH MM SS
+        int address = 0x1234;
+
+        // Set up memory at address to have date bytes
+        // Year=26 (2026), Month=3, Day=21, Hour=12, Min=30, Sec=45
+        expect(memory.read(address)).andReturn((byte) bin2bcd(26)).anyTimes();
+        expect(memory.read(address + 1)).andReturn((byte) bin2bcd(3)).anyTimes();
+        expect(memory.read(address + 2)).andReturn((byte) bin2bcd(21)).anyTimes();
+        expect(memory.read(address + 3)).andReturn((byte) bin2bcd(12)).anyTimes();
+        expect(memory.read(address + 4)).andReturn((byte) bin2bcd(30)).anyTimes();
+        expect(memory.read(address + 5)).andReturn((byte) bin2bcd(45)).anyTimes();
+        replay(memory);
+
+        SetClockZSDOS.INS.start(control);
+        resetClearFlags();
+
+        // Write low byte of address
+        SetClockZSDOS.INS.write((byte) (address & 0xFF), control);
+        assertFalse(isCommandCleared());
+
+        // Write high byte of address
+        SetClockZSDOS.INS.write((byte) ((address >> 8) & 0xFF), control);
+        assertTrue(isCommandCleared());
+
+        verify(memory);
+    }
+
+    @Test
+    public void testResetClearsDelta() {
+        SetClockZSDOS.INS.ClockZSDOSDelta = 100;
+        SetClockZSDOS.INS.reset(control);
+        assertEquals(0, SetClockZSDOS.INS.ClockZSDOSDelta);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetTimerDeltaTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetTimerDeltaTest.java
@@ -1,0 +1,70 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SetTimerDeltaTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetTimerDelta.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsReadCommand() {
+        SetTimerDelta.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWriteTwoByteDelta() {
+        int delta = 500; // 500ms
+
+        SetTimerDelta.INS.start(control);
+        resetClearFlags();
+
+        // Write low byte
+        SetTimerDelta.INS.write((byte) (delta & 0xFF), control);
+        assertFalse(isCommandCleared());
+
+        // Write high byte
+        SetTimerDelta.INS.write((byte) ((delta >> 8) & 0xFF), control);
+        assertTrue(isCommandCleared());
+
+        assertEquals(delta, SetTimerDelta.INS.timerDelta);
+    }
+
+    @Test
+    public void testWriteZeroDeltaFallsBackToDefault() {
+        SetTimerDelta.INS.start(control);
+        resetClearFlags();
+
+        // Write 0
+        SetTimerDelta.INS.write((byte) 0, control);
+        SetTimerDelta.INS.write((byte) 0, control);
+
+        // Should fall back to default (100ms)
+        assertEquals(100, SetTimerDelta.INS.timerDelta);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        SetTimerDelta.INS.start(control);
+        // Write only first byte
+        SetTimerDelta.INS.write((byte) 0x10, control);
+        // Reset before second byte
+        SetTimerDelta.INS.reset(control);
+
+        SetTimerDelta.INS.start(control);
+        resetClearFlags();
+
+        // Should accept low byte again (position reset to 0)
+        SetTimerDelta.INS.write((byte) (200 & 0xFF), control);
+        assertFalse(isCommandCleared()); // expecting high byte next
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetTimerInterruptAdrTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetTimerInterruptAdrTest.java
@@ -1,0 +1,74 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SetTimerInterruptAdrTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        SetTimerInterruptAdr.INS.timerInterruptHandler = 0xFC00; // restore default
+        SetTimerInterruptAdr.INS.reset(control);
+    }
+
+    @Test
+    public void testStartClearsReadCommand() {
+        SetTimerInterruptAdr.INS.start(control);
+        assertTrue(isReadCommandCleared());
+    }
+
+    @Test
+    public void testWriteTwoByteAddress() {
+        int address = 0xFC00;
+
+        SetTimerInterruptAdr.INS.start(control);
+        resetClearFlags();
+
+        // Write low byte
+        SetTimerInterruptAdr.INS.write((byte) (address & 0xFF), control);
+        assertFalse(isCommandCleared());
+
+        // Write high byte
+        SetTimerInterruptAdr.INS.write((byte) ((address >> 8) & 0xFF), control);
+        assertTrue(isCommandCleared());
+
+        assertEquals(address, SetTimerInterruptAdr.INS.timerInterruptHandler);
+    }
+
+    @Test
+    public void testWriteAddressWithHighBitsSet() {
+        // Test that sign extension is handled correctly
+        int address = 0xFF80;
+
+        SetTimerInterruptAdr.INS.start(control);
+        resetClearFlags();
+
+        SetTimerInterruptAdr.INS.write((byte) (address & 0xFF), control);
+        SetTimerInterruptAdr.INS.write((byte) ((address >> 8) & 0xFF), control);
+
+        assertEquals(address, SetTimerInterruptAdr.INS.timerInterruptHandler);
+    }
+
+    @Test
+    public void testResetResetsPosition() {
+        SetTimerInterruptAdr.INS.start(control);
+        SetTimerInterruptAdr.INS.write((byte) 0x10, control);
+
+        SetTimerInterruptAdr.INS.reset(control);
+        SetTimerInterruptAdr.INS.start(control);
+        resetClearFlags();
+
+        // Should start from low byte again
+        SetTimerInterruptAdr.INS.write((byte) 0x00, control);
+        assertFalse(isCommandCleared());
+        SetTimerInterruptAdr.INS.write((byte) 0x10, control);
+        assertTrue(isCommandCleared());
+
+        assertEquals(0x1000, SetTimerInterruptAdr.INS.timerInterruptHandler);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetZ80CPUTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/SetZ80CPUTest.java
@@ -1,0 +1,17 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SetZ80CPUTest extends CommandTestBase {
+
+    @Test
+    public void testStartClearsCommand() {
+        SetZ80CPU.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ShowTimerTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/ShowTimerTest.java
@@ -1,0 +1,34 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ShowTimerTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        StartTimer.INS.reset(control);
+    }
+
+    @Test
+    public void testShowTimerWithActiveTimerClearsCommand() {
+        StartTimer.INS.start(control);
+        resetClearFlags();
+
+        ShowTimer.INS.start(control);
+        assertTrue(isCommandCleared());
+        // Timer should still be on the stack (not popped)
+        assertEquals(1, StartTimer.INS.markTimeSP);
+    }
+
+    @Test
+    public void testShowTimerWithNoActiveTimerClearsCommand() {
+        ShowTimer.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StartTimerInterruptsTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StartTimerInterruptsTest.java
@@ -1,0 +1,50 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class StartTimerInterruptsTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        replay(cpu);
+        StartTimerInterrupts.INS.reset(control);
+        reset(cpu);
+    }
+
+    @Test
+    public void testStartClearsCommand() {
+        cpu.addPassedCyclesListener(anyObject());
+        expectLastCall();
+        replay(cpu);
+
+        StartTimerInterrupts.INS.start(control);
+        assertTrue(isCommandCleared());
+        assertNotNull(StartTimerInterrupts.INS.callback.get());
+
+        verify(cpu);
+    }
+
+    @Test
+    public void testResetRemovesCallback() {
+        cpu.addPassedCyclesListener(anyObject());
+        expectLastCall();
+        cpu.removePassedCyclesListener(anyObject());
+        expectLastCall();
+        replay(cpu);
+
+        StartTimerInterrupts.INS.start(control);
+        assertNotNull(StartTimerInterrupts.INS.callback.get());
+
+        StartTimerInterrupts.INS.reset(control);
+        assertNull(StartTimerInterrupts.INS.callback.get());
+
+        verify(cpu);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StartTimerTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StartTimerTest.java
@@ -1,0 +1,53 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StartTimerTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        StartTimer.INS.reset(control);
+    }
+
+    @Test
+    public void testStartPushesTimerOntoStack() {
+        StartTimer.INS.start(control);
+        assertEquals(1, StartTimer.INS.markTimeSP);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testMultipleStartsPushMultipleTimers() {
+        StartTimer.INS.start(control);
+        StartTimer.INS.start(control);
+        StartTimer.INS.start(control);
+        assertEquals(3, StartTimer.INS.markTimeSP);
+    }
+
+    @Test
+    public void testStackOverflowIsHandledGracefully() {
+        // push 10 timers (stack limit)
+        for (int i = 0; i < 10; i++) {
+            StartTimer.INS.start(control);
+        }
+        assertEquals(10, StartTimer.INS.markTimeSP);
+
+        // 11th push should not increase the stack pointer
+        StartTimer.INS.start(control);
+        assertEquals(10, StartTimer.INS.markTimeSP);
+    }
+
+    @Test
+    public void testResetClearsStackPointer() {
+        StartTimer.INS.start(control);
+        StartTimer.INS.start(control);
+        StartTimer.INS.reset(control);
+        assertEquals(0, StartTimer.INS.markTimeSP);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StopTimerInterruptsTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StopTimerInterruptsTest.java
@@ -1,0 +1,44 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.*;
+import static org.junit.Assert.*;
+
+public class StopTimerInterruptsTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        replay(cpu);
+        StartTimerInterrupts.INS.reset(control);
+        reset(cpu);
+    }
+
+    @Test
+    public void testStartClearsCommand() {
+        StopTimerInterrupts.INS.start(control);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testStartStopsTimerInterrupts() {
+        cpu.addPassedCyclesListener(anyObject());
+        expectLastCall();
+        cpu.removePassedCyclesListener(anyObject());
+        expectLastCall();
+        replay(cpu);
+
+        StartTimerInterrupts.INS.start(control);
+        resetClearFlags();
+
+        StopTimerInterrupts.INS.start(control);
+        assertNull(StartTimerInterrupts.INS.callback.get());
+        assertTrue(isCommandCleared());
+
+        verify(cpu);
+    }
+}
+

--- a/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StopTimerTest.java
+++ b/plugins/device/simh-pseudo/src/test/java/net/emustudio/plugins/device/simh/commands/StopTimerTest.java
@@ -1,0 +1,45 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.device.simh.commands;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class StopTimerTest extends CommandTestBase {
+
+    @Before
+    public void setUp() {
+        StartTimer.INS.reset(control);
+    }
+
+    @Test
+    public void testStopTimerWithActiveTimer() {
+        StartTimer.INS.start(control);
+        resetClearFlags();
+
+        StopTimer.INS.start(control);
+
+        assertEquals(0, StartTimer.INS.markTimeSP);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testStopTimerWithNoActiveTimer() {
+        StopTimer.INS.start(control);
+        assertEquals(0, StartTimer.INS.markTimeSP);
+        assertTrue(isCommandCleared());
+    }
+
+    @Test
+    public void testStopTimerPopsFromStack() {
+        StartTimer.INS.start(control);
+        StartTimer.INS.start(control);
+        resetClearFlags();
+
+        StopTimer.INS.start(control);
+        assertEquals(1, StartTimer.INS.markTimeSP);
+    }
+}
+


### PR DESCRIPTION
…d lifecycle methods

- Fix byte sign-extension bug in SetTimerInterruptAdr, SetClockZSDOS, SetClockCPM3: mask incoming bytes with & 0xFF before shifting
- Fix missing reset() in GenInterrupt (genInterruptPos not cleared)
- Fix GetHostOSPathSeparator not clearing command after read
- Add missing start() to SetBankSelect (clearReadCommand)
- Extend Get/SetCPUClockFrequency, ReadStopWatch to 32-bit
- Add unit tests for all commands