### PR TITLE
[#382] as-z80: Fix JR emitting stray byte when label is also forward-…

### DIFF
--- a/plugins/compiler/as-z80/src/main/java/net/emustudio/plugins/compiler/asZ80/visitors/EvaluateExprVisitor.java
+++ b/plugins/compiler/as-z80/src/main/java/net/emustudio/plugins/compiler/asZ80/visitors/EvaluateExprVisitor.java
@@ -338,7 +338,10 @@ public class EvaluateExprVisitor extends NodeVisitor {
     }
 
     private void evalExpr(Node node) {
-        latestEval = node.eval(getCurrentAddress(), env);
+        // Defensive copy: env may return the same Evaluated object for different references to the same label.
+        // Without copying, setMaxValue on one reference (e.g. from CALL with sizeBytes=2) would mutate the
+        // object already attached as a child of another instruction (e.g. JR with sizeBytes=1).
+        latestEval = node.eval(getCurrentAddress(), env).map(e -> (Evaluated) e.copy());
         latestEval.ifPresent(e -> node.getMaxValue().ifPresent(e::setMaxValue));
         latestEval.ifPresentOrElse(
                 e -> node.remove().ifPresent(p -> p.addChild(e)),

--- a/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/e2e/AssemblerZ80Test.java
+++ b/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/e2e/AssemblerZ80Test.java
@@ -936,4 +936,41 @@ public class AssemblerZ80Test extends AbstractCompilerTest {
                 0xFD, 0xE5
         );
     }
+
+    @Test
+    public void testCallForwardAndJrBackwardToSameLabel() {
+        // Regression: when call (forward ref) and jr (backward ref) reference
+        // the same label, the jr operand must be 1 byte (not 2).
+        // Previously, the shared Evaluated object had its sizeBytes mutated
+        // from 1 to 2 by the call resolution, causing jr to emit an extra byte.
+        compile(
+                "call myproc\n" +
+                        "halt\n" +
+                        "myproc: ld a, (hl)\n" +
+                        "or a\n" +
+                        "ret z\n" +
+                        "inc hl\n" +
+                        "jr myproc\n" +
+                        "done: nop\n"
+        );
+
+        assertProgram(
+                // call myproc → CD 04 00
+                0xCD, 0x04, 0x00,
+                // halt → 76
+                0x76,
+                // myproc: ld a,(hl) → 7E
+                0x7E,
+                // or a → B7
+                0xB7,
+                // ret z → C8
+                0xC8,
+                // inc hl → 23
+                0x23,
+                // jr myproc → 18 FA (offset = 0x04 - 0x0A = -6)
+                0x18, 0xFA,
+                // done: nop → 00 (must be at 0x0A, no stray 0xFF)
+                0x00
+        );
+    }
 }


### PR DESCRIPTION
…referenced by CALL

- JR/DJNZ emits 3 bytes instead of 2 when the target label is also used by a forward-referencing CALL
- The stray 0xFF byte shifts all subsequent addresses by 1, silently corrupting the output
- Root cause: shared Evaluated object from env is  mutated by CALL resolution (sizeBytes 1 -> 2), corrupting JR operand already in the AST
- Fix: defensive copy of Evaluated in evalExpr() before modifying and attaching it to the tree
- Add regression test: CALL forward + JR backward to the same label