### PR TITLE
[#384] as-z80: Simplify grammar/parsing, fix bugs, add tests

### DIFF
--- a/plugins/compiler/as-z80/src/main/antlr/AsZ80Lexer.g4
+++ b/plugins/compiler/as-z80/src/main/antlr/AsZ80Lexer.g4
@@ -103,14 +103,14 @@ OPCODE_SUB: S U B;
 OPCODE_XOR: X O R;
 
 mode CONDITION;
-COND_C:  C   ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_NC: N C ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_Z:  Z   ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_NZ: N Z ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_M:  M   ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_PE: P E ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_PO: P O ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
-COND_P:  P   ({(_input.LA(1) == -1) || (" ,\t\f\n\r;#/'\"()[]{}!=-+*<>\\%^&|$.".indexOf((char)_input.LA(1)) != -1) }?) -> popMode;
+COND_C:  C   ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_NC: N C ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_Z:  Z   ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_NZ: N Z ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_M:  M   ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_PE: P E ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_PO: P O ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
+COND_P:  P   ({_input.LA(1) == -1 || (!Character.isLetterOrDigit((char)_input.LA(1)) && "_?@".indexOf((char)_input.LA(1)) == -1)}?) -> popMode;
 COND_WS: [ \t\f]+ -> channel(HIDDEN);
 ERROR_COND: () -> popMode,skip;
 

--- a/plugins/compiler/as-z80/src/main/antlr/AsZ80Parser.g4
+++ b/plugins/compiler/as-z80/src/main/antlr/AsZ80Parser.g4
@@ -7,8 +7,7 @@ options {
 }
 
 rStart:
- (rLine EOL rLine)* (PREP_END comment (EOL comment)*)? EOF
- | rLine EOF
+ (rLine EOL)* rLine? (PREP_END comment (EOL comment)*)? EOF
  ;
 
 rLine:
@@ -26,27 +25,10 @@ rStatement:
   ;
 
 rInstruction:
-  opcode=OPCODE_RLC d=rDisplacement SEP_COMMA r=rRegister2                      # instrXDCB_R
-  | opcode=OPCODE_RRC d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-  | opcode=OPCODE_RL d=rDisplacement SEP_COMMA r=rRegister2                     # instrXDCB_R
-  | opcode=OPCODE_RR d=rDisplacement SEP_COMMA r=rRegister2                     # instrXDCB_R
-  | opcode=OPCODE_SLA d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-  | opcode=OPCODE_SRA d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-  | opcode=OPCODE_SLL d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-  | opcode=OPCODE_SRL d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-  | opcode=OPCODE_SRL d=rDisplacement                                           # instrXDCB
-  | opcode=OPCODE_RLC d=rDisplacement                                           # instrXDCB
-  | opcode=OPCODE_RRC d=rDisplacement                                           # instrXDCB
-  | opcode=OPCODE_RL d=rDisplacement                                            # instrXDCB
-  | opcode=OPCODE_RR d=rDisplacement                                            # instrXDCB
-  | opcode=OPCODE_SLA d=rDisplacement                                           # instrXDCB
-  | opcode=OPCODE_SRA d=rDisplacement                                           # instrXDCB
-  | opcode=OPCODE_SLL d=rDisplacement                                           # instrXDCB
-  | opcode=OPCODE_BIT n=rExpression SEP_COMMA d=rDisplacement                   # instrXDCB_N
-  | opcode=OPCODE_RES n=rExpression SEP_COMMA d=rDisplacement                   # instrXDCB_N
-  | opcode=OPCODE_SET n=rExpression SEP_COMMA d=rDisplacement                   # instrXDCB_N
-  | opcode=OPCODE_RES n=rExpression SEP_COMMA d=rDisplacement SEP_COMMA r=rRegister2  # instrXDCB_N_R
-  | opcode=OPCODE_SET n=rExpression SEP_COMMA d=rDisplacement SEP_COMMA r=rRegister2  # instrXDCB_N_R
+  opcode=(OPCODE_RLC|OPCODE_RRC|OPCODE_RL|OPCODE_RR|OPCODE_SLA|OPCODE_SRA|OPCODE_SLL|OPCODE_SRL) d=rDisplacement SEP_COMMA r=rRegister2  # instrXDCB_R
+  | opcode=(OPCODE_RLC|OPCODE_RRC|OPCODE_RL|OPCODE_RR|OPCODE_SLA|OPCODE_SRA|OPCODE_SLL|OPCODE_SRL) d=rDisplacement                       # instrXDCB
+  | opcode=(OPCODE_BIT|OPCODE_RES|OPCODE_SET) n=rExpression SEP_COMMA d=rDisplacement SEP_COMMA r=rRegister2                               # instrXDCB_N_R
+  | opcode=(OPCODE_BIT|OPCODE_RES|OPCODE_SET) n=rExpression SEP_COMMA d=rDisplacement                                                      # instrXDCB_N
 
   | opcode=OPCODE_IN r=rRegister2 SEP_COMMA SEP_LPAR REG_C SEP_RPAR             # instrED_R2
   | opcode=OPCODE_OUT SEP_LPAR REG_C SEP_RPAR SEP_COMMA r=rRegister2            # instrED_R2
@@ -61,39 +43,10 @@ rInstruction:
   | opcode=OPCODE_LD dst=REG_A SEP_COMMA src=REG_I                              # instrED_RIA_RIA
   | opcode=OPCODE_LD dst=REG_R SEP_COMMA src=REG_A                              # instrED_RIA_RIA
   | opcode=OPCODE_LD dst=REG_A SEP_COMMA src=REG_R                              # instrED_RIA_RIA
-  | opcode=OPCODE_NEG                                                           # instrED
-  | opcode=OPCODE_RETN                                                          # instrED
-  | opcode=OPCODE_RETI                                                          # instrED
-  | opcode=OPCODE_LDI                                                           # instrED
-  | opcode=OPCODE_LDIR                                                          # instrED
-  | opcode=OPCODE_CPI                                                           # instrED
-  | opcode=OPCODE_CPIR                                                          # instrED
-  | opcode=OPCODE_INI                                                           # instrED
-  | opcode=OPCODE_INIR                                                          # instrED
-  | opcode=OPCODE_OUTI                                                          # instrED
-  | opcode=OPCODE_OTIR                                                          # instrED
-  | opcode=OPCODE_LDD                                                           # instrED
-  | opcode=OPCODE_LDDR                                                          # instrED
-  | opcode=OPCODE_CPD                                                           # instrED
-  | opcode=OPCODE_CPDR                                                          # instrED
-  | opcode=OPCODE_IND                                                           # instrED
-  | opcode=OPCODE_INDR                                                          # instrED
-  | opcode=OPCODE_OUTD                                                          # instrED
-  | opcode=OPCODE_OTDR                                                          # instrED
-  | opcode=OPCODE_RLD                                                           # instrED
-  | opcode=OPCODE_RRD                                                           # instrED
+  | opcode=(OPCODE_NEG|OPCODE_RETN|OPCODE_RETI|OPCODE_RLD|OPCODE_RRD|OPCODE_LDI|OPCODE_LDIR|OPCODE_CPI|OPCODE_CPIR|OPCODE_INI|OPCODE_INIR|OPCODE_OUTI|OPCODE_OTIR|OPCODE_LDD|OPCODE_LDDR|OPCODE_CPD|OPCODE_CPDR|OPCODE_IND|OPCODE_INDR|OPCODE_OUTD|OPCODE_OTDR)  # instrED
 
-  | opcode=OPCODE_RLC r=rRegister                                               # instrCB
-  | opcode=OPCODE_RRC r=rRegister                                               # instrCB
-  | opcode=OPCODE_RL r=rRegister                                                # instrCB
-  | opcode=OPCODE_RR r=rRegister                                                # instrCB
-  | opcode=OPCODE_SLA r=rRegister                                               # instrCB
-  | opcode=OPCODE_SRA r=rRegister                                               # instrCB
-  | opcode=OPCODE_SLL r=rRegister                                               # instrCB
-  | opcode=OPCODE_SRL r=rRegister                                               # instrCB
-  | opcode=OPCODE_BIT n=rExpression SEP_COMMA r=rRegister                       # instrCB_N_R
-  | opcode=OPCODE_RES n=rExpression SEP_COMMA r=rRegister                       # instrCB_N_R
-  | opcode=OPCODE_SET n=rExpression SEP_COMMA r=rRegister                       # instrCB_N_R
+  | opcode=(OPCODE_RLC|OPCODE_RRC|OPCODE_RL|OPCODE_RR|OPCODE_SLA|OPCODE_SRA|OPCODE_SLL|OPCODE_SRL) r=rRegister  # instrCB
+  | opcode=(OPCODE_BIT|OPCODE_RES|OPCODE_SET) n=rExpression SEP_COMMA r=rRegister                                # instrCB_N_R
 
   | opcode=OPCODE_LD ii=rII SEP_COMMA SEP_LPAR nn=rExpression SEP_RPAR          # instrXD_II_Ref_NN // must be above plain nn
   | opcode=OPCODE_LD ii=rII SEP_COMMA nn=rExpression                            # instrXD_II_NN
@@ -107,38 +60,21 @@ rInstruction:
   | opcode=OPCODE_LD d=rDisplacement SEP_COMMA r=rRegister2                     # instrXD_Ref_II_N_R
   | opcode=OPCODE_LD r=rRegister2 SEP_COMMA d=rDisplacement                     # instrXD_R_Ref_II_N
 
-  | opcode=OPCODE_INC d=rDisplacement                                           # instrXD_Ref_II_N
-  | opcode=OPCODE_DEC d=rDisplacement                                           # instrXD_Ref_II_N
-  | opcode=OPCODE_ADD REG_A SEP_COMMA d=rDisplacement                           # instrXD_Ref_II_N
-  | opcode=OPCODE_ADC REG_A SEP_COMMA d=rDisplacement                           # instrXD_Ref_II_N
-  | opcode=OPCODE_SBC REG_A SEP_COMMA d=rDisplacement                           # instrXD_Ref_II_N
-  | opcode=OPCODE_SUB d=rDisplacement                                           # instrXD_Ref_II_N
-  | opcode=OPCODE_AND d=rDisplacement                                           # instrXD_Ref_II_N
-  | opcode=OPCODE_XOR d=rDisplacement                                           # instrXD_Ref_II_N
-  | opcode=OPCODE_OR d=rDisplacement                                            # instrXD_Ref_II_N
-  | opcode=OPCODE_CP d=rDisplacement                                            # instrXD_Ref_II_N
+  | opcode=(OPCODE_INC|OPCODE_DEC) d=rDisplacement                              # instrXD_Ref_II_N
+  | opcode=(OPCODE_ADD|OPCODE_ADC|OPCODE_SBC) REG_A SEP_COMMA d=rDisplacement   # instrXD_Ref_II_N
+  | opcode=(OPCODE_SUB|OPCODE_AND|OPCODE_XOR|OPCODE_OR|OPCODE_CP) d=rDisplacement  # instrXD_Ref_II_N
 
-  | opcode=OPCODE_INC ii=rII_HL                                                 # instrXD_IIHL
-  | opcode=OPCODE_DEC ii=rII_HL                                                 # instrXD_IIHL
-  | opcode=OPCODE_ADD REG_A SEP_COMMA ii=rII_HL                                 # instrXD_IIHL
-  | opcode=OPCODE_ADC REG_A SEP_COMMA ii=rII_HL                                 # instrXD_IIHL
-  | opcode=OPCODE_SBC REG_A SEP_COMMA ii=rII_HL                                 # instrXD_IIHL
-  | opcode=OPCODE_SUB ii=rII_HL                                                 # instrXD_IIHL
-  | opcode=OPCODE_AND ii=rII_HL                                                 # instrXD_IIHL
-  | opcode=OPCODE_XOR ii=rII_HL                                                 # instrXD_IIHL
-  | opcode=OPCODE_OR ii=rII_HL                                                  # instrXD_IIHL
-  | opcode=OPCODE_CP ii=rII_HL                                                  # instrXD_IIHL
+  | opcode=(OPCODE_INC|OPCODE_DEC) ii=rII_HL                                    # instrXD_IIHL
+  | opcode=(OPCODE_ADD|OPCODE_ADC|OPCODE_SBC) REG_A SEP_COMMA ii=rII_HL         # instrXD_IIHL
+  | opcode=(OPCODE_SUB|OPCODE_AND|OPCODE_XOR|OPCODE_OR|OPCODE_CP) ii=rII_HL     # instrXD_IIHL
 
-  | opcode=OPCODE_INC ii=rII                                                    # instrXD_II
-  | opcode=OPCODE_DEC ii=rII                                                    # instrXD_II
-  | opcode=OPCODE_POP ii=rII                                                    # instrXD_II
+  | opcode=(OPCODE_INC|OPCODE_DEC) ii=rII                                       # instrXD_II
+  | opcode=(OPCODE_POP|OPCODE_PUSH) ii=rII                                      # instrXD_II
   | opcode=OPCODE_JP SEP_LPAR ii=rII SEP_RPAR                                   # instrXD_II
   | opcode=OPCODE_LD REG_SP SEP_COMMA ii=rII                                    # instrXD_II
   | opcode=OPCODE_EX SEP_LPAR REG_SP SEP_RPAR SEP_COMMA ii=rII                  # instrXD_II
-  | opcode=OPCODE_PUSH ii=rII                                                   # instrXD_II
 
-  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA r=REG_HL        # instrRef_NN_R
-  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA r=REG_A         # instrRef_NN_R
+  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA r=(REG_HL|REG_A)  # instrRef_NN_R
 
   | opcode=OPCODE_LD rp=REG_HL SEP_COMMA SEP_LPAR nn=rExpression SEP_RPAR       # instrRP_Ref_NN // x=0, z=2, q=1, p=2
 
@@ -159,128 +95,52 @@ rInstruction:
 
   | opcode=OPCODE_RET c=cCondition                                              # instrC        // x=3, z=0, y=cc
 
-  | opcode=OPCODE_JP c=cCondition SEP_COMMA nn=rExpression                      # instrC_NN     // x=3, z=2, y=cc
-  | opcode=OPCODE_CALL c=cCondition SEP_COMMA nn=rExpression                    # instrC_NN     // x=3, z=4, y=cc
+  | opcode=(OPCODE_JP|OPCODE_CALL) c=cCondition SEP_COMMA nn=rExpression        # instrC_NN     // x=3, z=2 or 4, y=cc
 
   | opcode=OPCODE_LD rp=rRegPair SEP_COMMA nn=rExpression                       # instrRP_NN  // x=0, z=1, q=0, p=rp
 
-  | opcode=OPCODE_EX dst=REG_AF SEP_COMMA src=REG_AFF                           # instrRP_RP  // x=0, z=0, y=1
+  | opcode=OPCODE_EX dst=REG_AF SEP_COMMA src=REG_AFF                           # instrRP_RP  // x=0, z=0, q=1, p=0
   | opcode=OPCODE_LD dst=REG_SP SEP_COMMA src=REG_HL                            # instrRP_RP    // x=3, z=1, q=1, p=3
   | opcode=OPCODE_EX dst=REG_DE SEP_COMMA src=REG_HL                            # instrRP_RP    // x=3, z=3, y=5
 
-  | opcode=OPCODE_JP nn=rExpression                                             # instrNN       // x=3, z=3, y=0
-  | opcode=OPCODE_CALL nn=rExpression                                           # instrNN       // x=3, z=5, q=1, p=0
+  | opcode=(OPCODE_JP|OPCODE_CALL) nn=rExpression                               # instrNN       // x=3, z=3 or 5
 
   | opcode=OPCODE_DJNZ n=rExpression                                            # instrN      // x=0, z=0, y=2
   | opcode=OPCODE_JR n=rExpression                                              # instrN      // x=0, z=0, y=3
   | opcode=OPCODE_OUT SEP_LPAR n=rExpression SEP_RPAR SEP_COMMA REG_A           # instrN        // x=3, z=3, y=2
   | opcode=OPCODE_IN REG_A SEP_COMMA SEP_LPAR n=rExpression SEP_RPAR            # instrN        // x=3, z=3, y=3
-  | opcode=OPCODE_ADD REG_A SEP_COMMA n=rExpression                             # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_ADC REG_A SEP_COMMA n=rExpression                             # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_SUB n=rExpression                                             # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_SBC REG_A SEP_COMMA n=rExpression                             # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_AND n=rExpression                                             # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_XOR n=rExpression                                             # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_OR n=rExpression                                              # instrN        // x=3, z=6, y=alu
-  | opcode=OPCODE_CP n=rExpression                                              # instrN        // x=3, z=6, y=alu
+  | opcode=(OPCODE_ADD|OPCODE_ADC|OPCODE_SBC) REG_A SEP_COMMA n=rExpression     # instrN        // x=3, z=6, y=alu
+  | opcode=(OPCODE_SUB|OPCODE_AND|OPCODE_XOR|OPCODE_OR|OPCODE_CP) n=rExpression # instrN        // x=3, z=6, y=alu
   | opcode=OPCODE_RST n=rExpression                                             # instrN        // x=3, z=7, y=N/8
 
   | opcode=OPCODE_ADD REG_HL SEP_COMMA rp=rRegPair                              # instrRP     // x=0, z=1, q=1, p=rp
-  | opcode=OPCODE_INC rp=rRegPair                                               # instrRP       // x=0, z=3, q=0, p=rp
-  | opcode=OPCODE_DEC rp=rRegPair                                               # instrRP       // x=0, z=3, q=1, p=rp
+  | opcode=(OPCODE_INC|OPCODE_DEC) rp=rRegPair                                  # instrRP       // x=0, z=3, q=0 or 1, p=rp
 
-  | opcode=OPCODE_POP rp2=rRegPair2                                             # instrRP2      // x=3, z=1, q=0, p=rp2
-  | opcode=OPCODE_PUSH rp2=rRegPair2                                            # instrRP2      // x=3, z=5, q=0, p=rp2
+  | opcode=(OPCODE_POP|OPCODE_PUSH) rp2=rRegPair2                               # instrRP2      // x=3, z=1 or 5, q=0, p=rp2
 
-  | opcode=OPCODE_ADD REG_A SEP_COMMA r=rRegister                               # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_ADC REG_A SEP_COMMA r=rRegister                               # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_SUB r=rRegister                                               # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_SBC REG_A SEP_COMMA r=rRegister                               # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_AND r=rRegister                                               # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_XOR r=rRegister                                               # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_OR r=rRegister                                                # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_CP r=rRegister                                                # instrR        // x=2, y=alu, z=r
-  | opcode=OPCODE_INC r=rRegister                                               # instrR        // x=0, z=4, y=r
-  | opcode=OPCODE_DEC r=rRegister                                               # instrR        // x=0, z=5, y=r
+  | opcode=(OPCODE_ADD|OPCODE_ADC|OPCODE_SBC) REG_A SEP_COMMA r=rRegister       # instrR        // x=2, y=alu, z=r
+  | opcode=(OPCODE_SUB|OPCODE_AND|OPCODE_XOR|OPCODE_OR|OPCODE_CP) r=rRegister   # instrR        // x=2, y=alu, z=r
+  | opcode=(OPCODE_INC|OPCODE_DEC) r=rRegister                                  # instrR        // x=0, z=4 or 5, y=r
 
-  | opcode=OPCODE_NOP                                                           # instr         // x=0, z=0, y=0
-  | opcode=OPCODE_RLCA                                                          # instr         // x=0, z=7, y=0
-  | opcode=OPCODE_RRCA                                                          # instr         // x=0, z=7, y=1
-  | opcode=OPCODE_RLA                                                           # instr         // x=0, z=7, y=2
-  | opcode=OPCODE_RRA                                                           # instr         // x=0, z=7, y=3
-  | opcode=OPCODE_DAA                                                           # instr         // x=0, z=7, y=4
-  | opcode=OPCODE_CPL                                                           # instr         // x=0, z=7, y=5
-  | opcode=OPCODE_SCF                                                           # instr         // x=0, z=7, y=6
-  | opcode=OPCODE_CCF                                                           # instr         // x=0, z=7, y=7
-  | opcode=OPCODE_HALT                                                          # instr         // x=1, z=6, y=6
-  | opcode=OPCODE_RET                                                           # instr         // x=3, z=1, q=1, p=0
-  | opcode=OPCODE_EXX                                                           # instr         // x=3, z=1, q=1, p=1
-  | opcode=OPCODE_DI                                                            # instr         // x=3, z=3, y=6
-  | opcode=OPCODE_EI                                                            # instr         // x=3, z=3, y=7
+  | opcode=(OPCODE_NOP|OPCODE_RLCA|OPCODE_RRCA|OPCODE_RLA|OPCODE_RRA|OPCODE_DAA|OPCODE_CPL|OPCODE_SCF|OPCODE_CCF|OPCODE_HALT|OPCODE_RET|OPCODE_EXX|OPCODE_DI|OPCODE_EI)  # instr
   ;
 
-rRegister:
-  r=REG_A
-  | r=REG_B
-  | r=REG_C
-  | r=REG_D
-  | r=REG_E
-  | r=REG_H
-  | r=REG_L
-  | SEP_LPAR r=REG_HL SEP_RPAR
-  ;
+rRegister: r=(REG_A|REG_B|REG_C|REG_D|REG_E|REG_H|REG_L) | SEP_LPAR r=REG_HL SEP_RPAR;
 
-rRegister2:
-  REG_B
-  | REG_C
-  | REG_D
-  | REG_E
-  | REG_H
-  | REG_L
-  | REG_A
-  ;
+rRegister2: REG_B | REG_C | REG_D | REG_E | REG_H | REG_L | REG_A;
 
-rRegisterII:
-  REG_B
-  | REG_C
-  | REG_D
-  | REG_E
-  | REG_IXH
-  | REG_IXL
-  | REG_IYH
-  | REG_IYL
-  | REG_A
-  ;
+rRegisterII: REG_B | REG_C | REG_D | REG_E | REG_IXH | REG_IXL | REG_IYH | REG_IYL | REG_A;
 
-rRegPair:
-  REG_BC
-  | REG_DE
-  | REG_HL
-  | REG_SP
-  ;
+rRegPair: REG_BC | REG_DE | REG_HL | REG_SP;
 
-rRegPair2:
-  REG_BC
-  | REG_DE
-  | REG_HL
-  | REG_AF
-  ;
+rRegPair2: REG_BC | REG_DE | REG_HL | REG_AF;
 
-cCondition:
-  COND_C
-  | COND_NC
-  | COND_Z
-  | COND_NZ
-  | COND_M
-  | COND_P
-  | COND_PE
-  | COND_PO
-  ;
+cCondition: COND_C | COND_NC | COND_Z | COND_NZ | COND_M | COND_P | COND_PE | COND_PO;
 
 rII: REG_IX | REG_IY;
 rII_HL: REG_IXH | REG_IYH | REG_IXL | REG_IYL;
 
-rDisplacement: SEP_LPAR ii=rII '+' n=rExpression SEP_RPAR;
+rDisplacement: SEP_LPAR ii=rII op=(OP_ADD|OP_SUBTRACT) n=rExpression SEP_RPAR;
 
 rPseudoCode:
   PREP_ORG expr=rExpression                                                                # pseudoOrg

--- a/plugins/compiler/as-z80/src/main/java/net/emustudio/plugins/compiler/asZ80/visitors/CreateInstrVisitor.java
+++ b/plugins/compiler/as-z80/src/main/java/net/emustudio/plugins/compiler/asZ80/visitors/CreateInstrVisitor.java
@@ -6,6 +6,7 @@ import net.emustudio.plugins.compiler.asZ80.AsZ80ParserBaseVisitor;
 import net.emustudio.plugins.compiler.asZ80.CompilerTables;
 import net.emustudio.plugins.compiler.asZ80.Pair;
 import net.emustudio.plugins.compiler.asZ80.ast.Node;
+import net.emustudio.plugins.compiler.asZ80.ast.expr.ExprUnary;
 import net.emustudio.plugins.compiler.asZ80.ast.instr.*;
 
 import java.util.HashMap;
@@ -15,75 +16,84 @@ import java.util.Objects;
 import static net.emustudio.plugins.compiler.asZ80.AsZ80Parser.*;
 
 public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
+    private static final Map<Integer, int[]> INSTR_XYZ = new HashMap<>();
+
+    static {
+        INSTR_XYZ.put(OPCODE_NOP, new int[]{0, 0, 0});
+        INSTR_XYZ.put(OPCODE_RLCA, new int[]{0, 0, 7});
+        INSTR_XYZ.put(OPCODE_RRCA, new int[]{0, 1, 7});
+        INSTR_XYZ.put(OPCODE_RLA, new int[]{0, 2, 7});
+        INSTR_XYZ.put(OPCODE_RRA, new int[]{0, 3, 7});
+        INSTR_XYZ.put(OPCODE_DAA, new int[]{0, 4, 7});
+        INSTR_XYZ.put(OPCODE_CPL, new int[]{0, 5, 7});
+        INSTR_XYZ.put(OPCODE_SCF, new int[]{0, 6, 7});
+        INSTR_XYZ.put(OPCODE_CCF, new int[]{0, 7, 7});
+        INSTR_XYZ.put(OPCODE_HALT, new int[]{1, 6, 6});
+        INSTR_XYZ.put(OPCODE_RET, new int[]{3, 1, 1});
+        INSTR_XYZ.put(OPCODE_EXX, new int[]{3, 3, 1});
+        INSTR_XYZ.put(OPCODE_DI, new int[]{3, 6, 3});
+        INSTR_XYZ.put(OPCODE_EI, new int[]{3, 7, 3});
+    }
+
     private final String sourceFileName;
 
     public CreateInstrVisitor(String sourceFileName) {
         this.sourceFileName = Objects.requireNonNull(sourceFileName);
     }
 
+    /**
+     * Wraps the displacement expression in a unary minus if the displacement operator is OP_SUBTRACT.
+     */
+    private Node visitDisplacementExpr(RDisplacementContext d) {
+        Node expr = exprVisitor().visit(d.n);
+        if (d.op.getType() == OP_SUBTRACT) {
+            ExprUnary unary = new ExprUnary(sourceFileName, d.op);
+            unary.addChild(expr);
+            return unary.setSizeBytes(1);
+        }
+        return expr.setSizeBytes(1);
+    }
+
     @Override
     public Node visitInstrXDCB_R(InstrXDCB_RContext ctx) {
-        //  opcode=OPCODE_RLC d=rDisplacement SEP_COMMA r=rRegister2                      # instrXDCB_R
-        //  | opcode=OPCODE_RRC d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-        //  | opcode=OPCODE_RL d=rDisplacement SEP_COMMA r=rRegister2                     # instrXDCB_R
-        //  | opcode=OPCODE_RR d=rDisplacement SEP_COMMA r=rRegister2                     # instrXDCB_R
-        //  | opcode=OPCODE_SLA d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-        //  | opcode=OPCODE_SRA d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-        //  | opcode=OPCODE_SLL d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
-        //  | opcode=OPCODE_SRL d=rDisplacement SEP_COMMA r=rRegister2                    # instrXDCB_R
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         int y = CompilerTables.rot.get(ctx.opcode.getType());
         int z = CompilerTables.registers.get(ctx.r.start.getType());
         Node instr = new InstrXDCB(sourceFileName, ctx.opcode, prefix, y, z).setSizeBytes(4);
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrXDCB(InstrXDCBContext ctx) {
-        //  | opcode=OPCODE_SRL d=rDisplacement                                           # instrXDCB
-        //  | opcode=OPCODE_RLC d=rDisplacement                                           # instrXDCB
-        //  | opcode=OPCODE_RRC d=rDisplacement                                           # instrXDCB
-        //  | opcode=OPCODE_RL d=rDisplacement                                            # instrXDCB
-        //  | opcode=OPCODE_RR d=rDisplacement                                            # instrXDCB
-        //  | opcode=OPCODE_SLA d=rDisplacement                                           # instrXDCB
-        //  | opcode=OPCODE_SRA d=rDisplacement                                           # instrXDCB
-        //  | opcode=OPCODE_SLL d=rDisplacement                                           # instrXDCB
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         int y = CompilerTables.rot.get(ctx.opcode.getType());
         Node instr = new InstrXDCB(sourceFileName, ctx.opcode, prefix, y, 6).setSizeBytes(4);
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrXDCB_N(InstrXDCB_NContext ctx) {
-        // | opcode=OPCODE_BIT n=rExpression SEP_COMMA d=rDisplacement                   # instrXDCB_N
-        // | opcode=OPCODE_RES n=rExpression SEP_COMMA d=rDisplacement                   # instrXDCB_N
-        // | opcode=OPCODE_SET n=rExpression SEP_COMMA d=rDisplacement                   # instrXDCB_N
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         Node instr = new InstrXDCB(sourceFileName, ctx.opcode, prefix, 0, 6).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.n).setMaxValue(7));
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrXDCB_N_R(InstrXDCB_N_RContext ctx) {
-        //  | opcode=OPCODE_RES n=rExpression SEP_COMMA d=rDisplacement SEP_COMMA r=rRegister2  # instrXDCB_N_R
-        //  | opcode=OPCODE_SET n=rExpression SEP_COMMA d=rDisplacement SEP_COMMA r=rRegister2  # instrXDCB_N_R
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         int z = CompilerTables.registers.get(ctx.r.start.getType());
         Node instr = new InstrXDCB(sourceFileName, ctx.opcode, prefix, 0, z).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.n).setMaxValue(7));
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrED_R2(InstrED_R2Context ctx) {
-        //  | opcode=OPCODE_IN r=rRegister2 SEP_COMMA SEP_LPAR REG_C SEP_RPAR             # instrED_R2
-        //  | opcode=OPCODE_OUT SEP_LPAR REG_C SEP_RPAR SEP_COMMA r=rRegister2            # instrED_R2
         int y = CompilerTables.registers.get(ctx.r.start.getType());
         int z = (ctx.opcode.getType() == OPCODE_IN) ? 0 : 1;
         return new InstrED(sourceFileName, ctx.opcode, y, z).setSizeBytes(2);
@@ -91,16 +101,12 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrED_C(InstrED_CContext ctx) {
-        //  | opcode=OPCODE_IN SEP_LPAR REG_C SEP_RPAR                                    # instrED_C
-        //  | opcode=OPCODE_OUT SEP_LPAR REG_C SEP_RPAR SEP_COMMA n=LIT_NUMBER            # instrED_C
         int z = (ctx.opcode.getType() == OPCODE_IN) ? 0 : 1;
         return new InstrED(sourceFileName, ctx.opcode, 6, z).setSizeBytes(2);
     }
 
     @Override
     public Node visitInstrED_RP(InstrED_RPContext ctx) {
-        //  | opcode=OPCODE_SBC REG_HL SEP_COMMA rp=rRegPair                              # instrED_RP
-        //  | opcode=OPCODE_ADC REG_HL SEP_COMMA rp=rRegPair                              # instrED_RP
         int q = (ctx.opcode.getType() == OPCODE_SBC) ? 0 : 1;
         int p = CompilerTables.regPairs.get(ctx.rp.start.getType());
         return new InstrED(sourceFileName, ctx.opcode, p, q, 2).setSizeBytes(2);
@@ -108,37 +114,28 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrED_NN_RP(InstrED_NN_RPContext ctx) {
-        //  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA rp=rRegPair     # instrED_NN_RP
-        int q = 0;
         int p = CompilerTables.regPairs.get(ctx.rp.getType());
-        Node instr = new InstrED(sourceFileName, ctx.opcode, p, q, 3).setSizeBytes(4);
+        Node instr = new InstrED(sourceFileName, ctx.opcode, p, 0, 3).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
         return instr;
     }
 
     @Override
     public Node visitInstrED_RP_NN(InstrED_RP_NNContext ctx) {
-        //  | opcode=OPCODE_LD rp=rRegPair SEP_COMMA SEP_LPAR nn=rExpression SEP_RPAR     # instrED_RP_NN
-        int q = 1;
         int p = CompilerTables.regPairs.get(ctx.rp.getType());
-        Node instr = new InstrED(sourceFileName, ctx.opcode, p, q, 3).setSizeBytes(4);
+        Node instr = new InstrED(sourceFileName, ctx.opcode, p, 1, 3).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
         return instr;
     }
 
     @Override
     public Node visitInstrED_IM(InstrED_IMContext ctx) {
-        //  | opcode=OPCODE_IM im=(IM_0|IM_1|IM_2|IM_01)                                  # instrED_IM
         int y = CompilerTables.im.get(ctx.im.getType());
         return new InstrED(sourceFileName, ctx.opcode, y, 6).setSizeBytes(2);
     }
 
     @Override
     public Node visitInstrED_RIA_RIA(InstrED_RIA_RIAContext ctx) {
-        //  | opcode=OPCODE_LD dst=REG_I src=REG_A                                        # instrED_RIA_RIA
-        //  | opcode=OPCODE_LD dst=REG_R src=REG_A                                        # instrED_RIA_RIA
-        //  | opcode=OPCODE_LD dst=REG_A src=REG_I                                        # instrED_RIA_RIA
-        //  | opcode=OPCODE_LD dst=REG_A src=REG_R                                        # instrED_RIA_RIA
         int y = 0; // ctx.dst.getType() == REG_I
         if (ctx.dst.getType() == REG_R) {
             y = 1;
@@ -152,27 +149,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrED(InstrEDContext ctx) {
-        //  | opcode=OPCODE_NEG                                                           # instrED
-        //  | opcode=OPCODE_RETN                                                          # instrED
-        //  | opcode=OPCODE_RETI                                                          # instrED
-        //  | opcode=OPCODE_RLD                                                           # instrED
-        //  | opcode=OPCODE_RRD                                                           # instrED
-        //  | opcode=OPCODE_LDI                                                           # instrED
-        //  | opcode=OPCODE_LDIR                                                          # instrED
-        //  | opcode=OPCODE_CPI                                                           # instrED
-        //  | opcode=OPCODE_CPIR                                                          # instrED
-        //  | opcode=OPCODE_INI                                                           # instrED
-        //  | opcode=OPCODE_INIR                                                          # instrED
-        //  | opcode=OPCODE_OUTI                                                          # instrED
-        //  | opcode=OPCODE_OTIR                                                          # instrED
-        //  | opcode=OPCODE_LDD                                                           # instrED
-        //  | opcode=OPCODE_LDDR                                                          # instrED
-        //  | opcode=OPCODE_CPD                                                           # instrED
-        //  | opcode=OPCODE_CPDR                                                          # instrED
-        //  | opcode=OPCODE_IND                                                           # instrED
-        //  | opcode=OPCODE_INDR                                                          # instrED
-        //  | opcode=OPCODE_OUTD                                                          # instrED
-        //  | opcode=OPCODE_OTDR                                                          # instrED
         switch (ctx.opcode.getType()) {
             case OPCODE_NEG:
                 return new InstrED(sourceFileName, ctx.opcode, 0, 4).setSizeBytes(2);
@@ -185,21 +161,12 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
             case OPCODE_RLD:
                 return new InstrED(sourceFileName, ctx.opcode, 5, 7).setSizeBytes(2);
         }
-
         Pair<Integer, Integer> yz = CompilerTables.block.get(ctx.opcode.getType());
         return new InstrED(sourceFileName, ctx.opcode, yz.l, yz.r).setSizeBytes(2);
     }
 
     @Override
     public Node visitInstrCB(InstrCBContext ctx) {
-        //  | opcode=OPCODE_RLC r=rRegister                                               # instrCB
-        //  | opcode=OPCODE_RRC r=rRegister                                               # instrCB
-        //  | opcode=OPCODE_RL r=rRegister                                                # instrCB
-        //  | opcode=OPCODE_RR r=rRegister                                                # instrCB
-        //  | opcode=OPCODE_SLA r=rRegister                                               # instrCB
-        //  | opcode=OPCODE_SRA r=rRegister                                               # instrCB
-        //  | opcode=OPCODE_SLL r=rRegister                                               # instrCB
-        //  | opcode=OPCODE_SRL r=rRegister                                               # instrCB
         int y = CompilerTables.rot.get(ctx.opcode.getType());
         int z = CompilerTables.registers.get(ctx.r.r.getType());
         return new InstrCB(sourceFileName, ctx.opcode, y, z).setSizeBytes(2);
@@ -207,11 +174,7 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrCB_N_R(InstrCB_N_RContext ctx) {
-        //  | opcode=OPCODE_BIT n=rExpression SEP_COMMA r=rRegister                       # instrCB_N_R
-        //  | opcode=OPCODE_RES n=rExpression SEP_COMMA r=rRegister                       # instrCB_N_R
-        //  | opcode=OPCODE_SET n=rExpression SEP_COMMA r=rRegister                       # instrCB_N_R
         int z = CompilerTables.registers.get(ctx.r.r.getType());
-        // y needs to be computed from expr
         Node instr = new InstrCB(sourceFileName, ctx.opcode, 0, z).setSizeBytes(2);
         instr.addChild(exprVisitor().visit(ctx.n).setMaxValue(7));
         return instr;
@@ -219,7 +182,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_II_NN(InstrXD_II_NNContext ctx) {
-        //  | opcode=OPCODE_LD ii=rII SEP_COMMA nn=rExpression                            # instrXD_II_NN
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 0, 2, 1).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
@@ -228,7 +190,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_II_RP(InstrXD_II_RPContext ctx) {
-        //  | opcode=OPCODE_ADD ii=rII SEP_COMMA rp=(REG_BC|REG_DE|REG_IX|REG_IY|REG_SP)  # instrXD_II_RP
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         int p = CompilerTables.regPairsII.get(ctx.rp.getType());
         return new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 1, p, 1).setSizeBytes(2);
@@ -236,7 +197,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_Ref_NN_II(InstrXD_Ref_NN_IIContext ctx) {
-        //  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA ii=rII          # instrXD_Ref_NN_II
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 0, 2, 2).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
@@ -245,7 +205,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_II_Ref_NN(InstrXD_II_Ref_NNContext ctx) {
-        //  | opcode=OPCODE_LD ii=rII SEP_COMMA SEP_LPAR nn=rExpression SEP_RPAR          # instrXD_II_Ref_NN
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 1, 2, 2).setSizeBytes(4);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
@@ -254,7 +213,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_IIHL_N(InstrXD_IIHL_NContext ctx) {
-        //  | opcode=OPCODE_LD ii=rII_HL SEP_COMMA n=rExpression                          # instrXD_IIHL_N
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         int y = CompilerTables.registers.get(ctx.ii.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, y, 6).setSizeBytes(3);
@@ -264,17 +222,15 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_Ref_II_N_N(InstrXD_Ref_II_N_NContext ctx) {
-        //  | opcode=OPCODE_LD d=rDisplacement SEP_COMMA n=rExpression                    # instrXD_Ref_II_N_N
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 6, 6).setSizeBytes(4);
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         instr.addChild(exprVisitor().visit(ctx.n).setSizeBytes(1));
         return instr;
     }
 
     @Override
     public Node visitInstrXD_IIHL_R(InstrXD_IIHL_RContext ctx) {
-        //  | opcode=OPCODE_LD ii=rII_HL SEP_COMMA r=rRegisterII                          # instrXD_IIHL_R
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         int y = CompilerTables.registers.get(ctx.ii.start.getType());
         int z = CompilerTables.registers.get(ctx.r.start.getType());
@@ -283,7 +239,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_R_IIHL(InstrXD_R_IIHLContext ctx) {
-        //  | opcode=OPCODE_LD r=rRegisterII SEP_COMMA ii=rII_HL                          # instrXD_R_IIHL
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         int y = CompilerTables.registers.get(ctx.r.start.getType());
         int z = CompilerTables.registers.get(ctx.ii.start.getType());
@@ -292,68 +247,44 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_Ref_II_N_R(InstrXD_Ref_II_N_RContext ctx) {
-        //  | opcode=OPCODE_LD d=rDisplacement SEP_COMMA r=rRegister2                     # instrXD_Ref_II_N_R
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         int z = CompilerTables.registers.get(ctx.r.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 1, 6, z).setSizeBytes(3);
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrXD_R_Ref_II_N(InstrXD_R_Ref_II_NContext ctx) {
-        //  | opcode=OPCODE_LD r=rRegister2 SEP_COMMA d=rDisplacement                     # instrXD_R_Ref_II_N
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         int y = CompilerTables.registers.get(ctx.r.start.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 1, y, 6).setSizeBytes(3);
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrXD_Ref_II_N(InstrXD_Ref_II_NContext ctx) {
-        //  | opcode=OPCODE_INC d=rDisplacement                                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_DEC d=rDisplacement                                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_ADD REG_A SEP_COMMA d=rDisplacement                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_ADC REG_A SEP_COMMA d=rDisplacement                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_SBC REG_A SEP_COMMA d=rDisplacement                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_SUB d=rDisplacement                                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_AND d=rDisplacement                                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_XOR d=rDisplacement                                           # instrXD_Ref_II_N
-        //  | opcode=OPCODE_OR d=rDisplacement                                            # instrXD_Ref_II_N
-        //  | opcode=OPCODE_CP d=rDisplacement                                            # instrXD_Ref_II_N
         int prefix = CompilerTables.prefix.get(ctx.d.ii.start.getType());
         if (ctx.opcode.getType() == OPCODE_INC) {
             Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 6, 4).setSizeBytes(3);
-            instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+            instr.addChild(visitDisplacementExpr(ctx.d));
             return instr;
         } else if (ctx.opcode.getType() == OPCODE_DEC) {
             Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 0, 6, 5).setSizeBytes(3);
-            instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+            instr.addChild(visitDisplacementExpr(ctx.d));
             return instr;
         }
-
         int y = CompilerTables.alu.get(ctx.opcode.getType());
         Node instr = new InstrXD(sourceFileName, ctx.opcode, prefix, 2, y, 6).setSizeBytes(3);
-        instr.addChild(exprVisitor().visit(ctx.d.n).setSizeBytes(1));
+        instr.addChild(visitDisplacementExpr(ctx.d));
         return instr;
     }
 
     @Override
     public Node visitInstrXD_IIHL(InstrXD_IIHLContext ctx) {
-        //  | opcode=OPCODE_INC ii=rII_HL                                                 # instrXD_IIHL
-        //  | opcode=OPCODE_DEC ii=rII_HL                                                 # instrXD_IIHL
-        //  | opcode=OPCODE_ADD REG_A SEP_COMMA ii=rII_HL                                 # instrXD_IIHL
-        //  | opcode=OPCODE_ADC REG_A SEP_COMMA ii=rII_HL                                 # instrXD_IIHL
-        //  | opcode=OPCODE_SBC REG_A SEP_COMMA ii=rII_HL                                 # instrXD_IIHL
-        //  | opcode=OPCODE_SUB ii=rII_HL                                                 # instrXD_IIHL
-        //  | opcode=OPCODE_AND ii=rII_HL                                                 # instrXD_IIHL
-        //  | opcode=OPCODE_XOR ii=rII_HL                                                 # instrXD_IIHL
-        //  | opcode=OPCODE_OR ii=rII_HL                                                  # instrXD_IIHL
-        //  | opcode=OPCODE_CP ii=rII_HL                                                  # instrXD_IIHL
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         int r = CompilerTables.registers.get(ctx.ii.start.getType());
-
         if (ctx.opcode.getType() == OPCODE_INC) {
             return new InstrXD(sourceFileName, ctx.opcode, prefix, 0, r, 4).setSizeBytes(2);
         } else if (ctx.opcode.getType() == OPCODE_DEC) {
@@ -365,13 +296,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrXD_II(InstrXD_IIContext ctx) {
-        //  | opcode=OPCODE_INC ii=rII                                                    # instrXD_II
-        //  | opcode=OPCODE_DEC ii=rII                                                    # instrXD_II
-        //  | opcode=OPCODE_POP ii=rII                                                    # instrXD_II
-        //  | opcode=OPCODE_JP SEP_LPAR ii=rII SEP_RPAR                                   # instrXD_II
-        //  | opcode=OPCODE_LD REG_SP SEP_COMMA ii=rII                                    # instrXD_II
-        //  | opcode=OPCODE_EX SEP_LPAR REG_SP SEP_RPAR SEP_COMMA ii=rII                  # instrXD_II
-        //  | opcode=OPCODE_PUSH ii=rII                                                   # instrXD_II
         int prefix = CompilerTables.prefix.get(ctx.ii.start.getType());
         int opcode = ctx.opcode.getType();
         int x = (opcode == OPCODE_INC || opcode == OPCODE_DEC) ? 0 : 3;
@@ -392,8 +316,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRef_NN_R(InstrRef_NN_RContext ctx) {
-        //  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA r=REG_HL        # instrRef_NN_R // x=0, z=2, q=0, p=2
-        //  | opcode=OPCODE_LD SEP_LPAR nn=rExpression SEP_RPAR SEP_COMMA r=REG_A         # instrRef_NN_R // x=0, z=2, q=0, p=3
         int p = (ctx.r.getType() == REG_HL) ? 2 : 3;
         Node instr = new Instr(sourceFileName, ctx.opcode, 0, 0, p, 2).setSizeBytes(3);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
@@ -402,7 +324,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRP_Ref_NN(InstrRP_Ref_NNContext ctx) {
-        //  | opcode=OPCODE_LD rp=REG_HL SEP_COMMA SEP_LPAR nn=rExpression SEP_RPAR       # instrRP_Ref_NN // x=0, z=2, q=1, p=2
         Node instr = new Instr(sourceFileName, ctx.opcode, 0, 1, 2, 2).setSizeBytes(3);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
         return instr;
@@ -410,7 +331,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrR_Ref_NN(InstrR_Ref_NNContext ctx) {
-        //  | opcode=OPCODE_LD r=REG_A SEP_COMMA SEP_LPAR nn=rExpression SEP_RPAR         # instrR_Ref_NN  // x=0, z=2, q=1, p=3
         Node instr = new Instr(sourceFileName, ctx.opcode, 0, 1, 3, 2).setSizeBytes(3);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
         return instr;
@@ -418,15 +338,12 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrA_Ref_RP(InstrA_Ref_RPContext ctx) {
-        //  | opcode=OPCODE_LD REG_A SEP_COMMA SEP_LPAR rp=(REG_BC|REG_DE) SEP_RPAR       # instrA_Ref_RP // x=0, z=2, q=1, p=rp
         int p = CompilerTables.regPairs.get(ctx.rp.getType());
         return new Instr(sourceFileName, ctx.opcode, 0, 1, p, 2).setSizeBytes(1);
     }
 
     @Override
     public Node visitInstrRef_RP(InstrRef_RPContext ctx) {
-        //  | opcode=OPCODE_LD SEP_LPAR rp=(REG_BC|REG_DE) SEP_RPAR SEP_COMMA REG_A       # instrRef_RP   // x=0, z=2, q=0, p=rp
-        //  | opcode=OPCODE_JP SEP_LPAR rp=REG_HL SEP_RPAR                                # instrRef_RP   // x=3, z=1, q=1, p=2
         int p = CompilerTables.regPairs.get(ctx.rp.getType());
         int x = (ctx.opcode.getType() == OPCODE_LD) ? 0 : 3;
         int z = (ctx.opcode.getType() == OPCODE_LD) ? 2 : 1;
@@ -436,13 +353,11 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRef_RP_RP(InstrRef_RP_RPContext ctx) {
-        //  | opcode=OPCODE_EX SEP_LPAR dst=REG_SP SEP_RPAR SEP_COMMA src=REG_HL          # instrRef_RP_RP // x=3, z=3, y=4
         return new Instr(sourceFileName, ctx.opcode, 3, 4, 3).setSizeBytes(1);
     }
 
     @Override
     public Node visitInstrR_R(InstrR_RContext ctx) {
-        //  | opcode=OPCODE_LD dst=rRegister SEP_COMMA src=rRegister                      # instrR_R      // x=1, y=dst, z=src
         int y = CompilerTables.registers.get(ctx.dst.r.getType());
         int z = CompilerTables.registers.get(ctx.src.r.getType());
         return new Instr(sourceFileName, ctx.opcode, 1, y, z).setSizeBytes(1);
@@ -450,7 +365,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrR_N(InstrR_NContext ctx) {
-        //  | opcode=OPCODE_LD r=rRegister SEP_COMMA n=rExpression                        # instrR_N      // x=0, z=6, y=r
         int y = CompilerTables.registers.get(ctx.r.r.getType());
         Node instr = new Instr(sourceFileName, ctx.opcode, 0, y, 6).setSizeBytes(2);
         instr.addChild(exprVisitor().visit(ctx.n).setSizeBytes(1));
@@ -459,7 +373,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrC_N(InstrC_NContext ctx) {
-        //  | opcode=OPCODE_JR c=(COND_NZ|COND_Z|COND_NC|COND_C) SEP_COMMA n=rExpression  # instrC_N    // x=0, z=0, y=4..7
         int y = CompilerTables.conditions.get(ctx.c.getType()) + 4;
         Node instr = new Instr(sourceFileName, ctx.opcode, 0, y, 0).setSizeBytes(2);
         instr.addChild(exprVisitor().visit(ctx.n).setSizeBytes(1));
@@ -468,15 +381,12 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrC(InstrCContext ctx) {
-        //  | opcode=OPCODE_RET c=cCondition                                              # instrC        // x=3, z=0, y=cc
         int y = CompilerTables.conditions.get(ctx.c.start.getType());
         return new Instr(sourceFileName, ctx.opcode, 3, y, 0).setSizeBytes(1);
     }
 
     @Override
     public Node visitInstrC_NN(InstrC_NNContext ctx) {
-        //  | opcode=OPCODE_JP c=cCondition SEP_COMMA nn=rExpression                      # instrC_NN     // x=3, z=2, y=cc
-        //  | opcode=OPCODE_CALL c=cCondition SEP_COMMA nn=rExpression                    # instrC_NN     // x=3, z=4, y=cc
         int y = CompilerTables.conditions.get(ctx.c.start.getType());
         int z = (ctx.opcode.getType() == OPCODE_JP) ? 2 : 4;
         Node instr = new Instr(sourceFileName, ctx.opcode, 3, y, z).setSizeBytes(3);
@@ -486,7 +396,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRP_NN(InstrRP_NNContext ctx) {
-        //  | opcode=OPCODE_LD rp=rRegPair SEP_COMMA nn=rExpression                       # instrRP_NN  // x=0, z=1, q=0, p=rp
         int p = CompilerTables.regPairs.get(ctx.rp.start.getType());
         Node instr = new Instr(sourceFileName, ctx.opcode, 0, 0, p, 1).setSizeBytes(3);
         instr.addChild(exprVisitor().visit(ctx.nn).setSizeBytes(2));
@@ -495,9 +404,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRP_RP(InstrRP_RPContext ctx) {
-        //  | opcode=OPCODE_EX dst=REG_AF SEP_COMMA src=REG_AFF                           # instrRP_RP  // x=0, z=0, q=1, p=0
-        //  | opcode=OPCODE_LD dst=REG_SP SEP_COMMA src=REG_HL                            # instrRP_RP    // x=3, z=1, q=1, p=3
-        //  | opcode=OPCODE_EX dst=REG_DE SEP_COMMA src=REG_HL                            # instrRP_RP    // x=3, z=3, q=1, p=2
         int x = (ctx.opcode.getType() == OPCODE_EX && ctx.dst.getType() == REG_AF) ? 0 : 3;
         int z = (ctx.opcode.getType() == OPCODE_LD) ? 1 : ((ctx.dst.getType() == REG_AF) ? 0 : 3);
         int p = (ctx.opcode.getType() == OPCODE_LD) ? 3 : ((ctx.dst.getType() == REG_AF) ? 0 : 2);
@@ -506,8 +412,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrNN(InstrNNContext ctx) {
-        //  | opcode=OPCODE_JP nn=rExpression                                             # instrNN       // x=3, z=3, y=0
-        //  | opcode=OPCODE_CALL nn=rExpression                                           # instrNN       // x=3, z=5, y=1
         int z = (ctx.opcode.getType() == OPCODE_JP) ? 3 : 5;
         int y = (ctx.opcode.getType() == OPCODE_JP) ? 0 : 1;
         Node instr = new Instr(sourceFileName, ctx.opcode, 3, y, z).setSizeBytes(3);
@@ -517,19 +421,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrN(InstrNContext ctx) {
-        //  | opcode=OPCODE_DJNZ n=rExpression                                            # instrN      // x=0, z=0, y=2
-        //  | opcode=OPCODE_JR n=rExpression                                              # instrN      // x=0, z=0, y=3
-        //  | opcode=OPCODE_OUT SEP_LPAR n=rExpression SEP_RPAR SEP_COMMA REG_A           # instrN      // x=3, z=3, y=2
-        //  | opcode=OPCODE_IN REG_A SEP_COMMA SEP_LPAR n=rExpression SEP_RPAR            # instrN      // x=3, z=3, y=3
-        //  | opcode=OPCODE_ADD REG_A SEP_COMMA n=rExpression                             # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_ADC REG_A SEP_COMMA n=rExpression                             # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_SUB n=rExpression                                             # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_SBC REG_A SEP_COMMA n=rExpression                             # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_AND n=rExpression                                             # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_XOR n=rExpression                                             # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_OR n=rExpression                                              # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_CP n=rExpression                                              # instrN      // x=3, z=6, y=alu
-        //  | opcode=OPCODE_RST n=rExpression                                             # instrN      // x=3, z=7, y=N/8
         int opcode = ctx.opcode.getType();
 
         boolean djnzOrJr = opcode == OPCODE_DJNZ || opcode == OPCODE_JR;
@@ -547,9 +438,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRP(InstrRPContext ctx) {
-        //  | opcode=OPCODE_ADD REG_HL SEP_COMMA rp=rRegPair                              # instrRP     // x=0, z=1, q=1, p=rp
-        //  | opcode=OPCODE_INC rp=rRegPair                                               # instrRP       // x=0, z=3, q=0, p=rp
-        //  | opcode=OPCODE_DEC rp=rRegPair                                               # instrRP       // x=0, z=3, q=1, p=rp
         int q = (ctx.opcode.getType() == OPCODE_INC) ? 0 : 1;
         int p = CompilerTables.regPairs.get(ctx.rp.start.getType());
         int z = (ctx.opcode.getType() == OPCODE_ADD) ? 1 : 3;
@@ -558,8 +446,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrRP2(InstrRP2Context ctx) {
-        //  | opcode=OPCODE_POP rp2=rRegPair2                                             # instrRP2      // x=3, z=1, q=0, p=rp2
-        //  | opcode=OPCODE_PUSH rp2=rRegPair2                                            # instrRP2      // x=3, z=5, q=0, p=rp2
         int p = CompilerTables.regPairs2.get(ctx.rp2.start.getType());
         int z = (ctx.opcode.getType() == OPCODE_POP) ? 1 : 5;
         return new Instr(sourceFileName, ctx.opcode, 3, 0, p, z).setSizeBytes(1);
@@ -567,16 +453,6 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstrR(InstrRContext ctx) {
-        //  | opcode=OPCODE_ADD REG_A SEP_COMMA r=rRegister                               # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_ADC REG_A SEP_COMMA r=rRegister                               # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_SUB r=rRegister                                               # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_SBC REG_A SEP_COMMA r=rRegister                               # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_AND r=rRegister                                               # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_XOR r=rRegister                                               # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_OR r=rRegister                                                # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_CP r=rRegister                                                # instrR        // x=2, y=alu, z=r
-        //  | opcode=OPCODE_INC r=rRegister                                               # instrR        // x=0, z=4, y=r
-        //  | opcode=OPCODE_DEC r=rRegister                                               # instrR        // x=0, z=5, y=r
         int opcode = ctx.opcode.getType();
         boolean incDec = (opcode == OPCODE_INC || opcode == OPCODE_DEC);
         int reg = CompilerTables.registers.get(ctx.r.r.getType());
@@ -589,42 +465,11 @@ public class CreateInstrVisitor extends AsZ80ParserBaseVisitor<Node> {
 
     @Override
     public Node visitInstr(InstrContext ctx) {
-        //  | opcode=OPCODE_NOP                                                           # instr         // x=0, z=0, y=0
-        //  | opcode=OPCODE_RLCA                                                          # instr         // x=0, z=7, y=0
-        //  | opcode=OPCODE_RRCA                                                          # instr         // x=0, z=7, y=1
-        //  | opcode=OPCODE_RLA                                                           # instr         // x=0, z=7, y=2
-        //  | opcode=OPCODE_RRA                                                           # instr         // x=0, z=7, y=3
-        //  | opcode=OPCODE_DAA                                                           # instr         // x=0, z=7, y=4
-        //  | opcode=OPCODE_CPL                                                           # instr         // x=0, z=7, y=5
-        //  | opcode=OPCODE_SCF                                                           # instr         // x=0, z=7, y=6
-        //  | opcode=OPCODE_CCF                                                           # instr         // x=0, z=7, y=7
-        //  | opcode=OPCODE_HALT                                                          # instr         // x=1, z=6, y=6
-        //  | opcode=OPCODE_RET                                                           # instr         // x=3, z=1, q=1, p=0
-        //  | opcode=OPCODE_EXX                                                           # instr         // x=3, z=1, q=1, p=1
-        //  | opcode=OPCODE_DI                                                            # instr         // x=3, z=3, y=6
-        //  | opcode=OPCODE_EI                                                            # instr         // x=3, z=3, y=7
-
-        Map<Integer, int[]> xyz = new HashMap<>();
-        xyz.put(OPCODE_NOP, new int[]{0, 0, 0});
-        xyz.put(OPCODE_RLCA, new int[]{0, 0, 7});
-        xyz.put(OPCODE_RRCA, new int[]{0, 1, 7});
-        xyz.put(OPCODE_RLA, new int[]{0, 2, 7});
-        xyz.put(OPCODE_RRA, new int[]{0, 3, 7});
-        xyz.put(OPCODE_DAA, new int[]{0, 4, 7});
-        xyz.put(OPCODE_CPL, new int[]{0, 5, 7});
-        xyz.put(OPCODE_SCF, new int[]{0, 6, 7});
-        xyz.put(OPCODE_CCF, new int[]{0, 7, 7});
-        xyz.put(OPCODE_HALT, new int[]{1, 6, 6});
-        xyz.put(OPCODE_RET, new int[]{3, 1, 1});
-        xyz.put(OPCODE_EXX, new int[]{3, 3, 1});
-        xyz.put(OPCODE_DI, new int[]{3, 6, 3});
-        xyz.put(OPCODE_EI, new int[]{3, 7, 3});
-
-        int[] xyzValues = xyz.get(ctx.opcode.getType());
+        int[] xyzValues = INSTR_XYZ.get(ctx.opcode.getType());
         return new Instr(sourceFileName, ctx.opcode, xyzValues[0], xyzValues[1], xyzValues[2]).setSizeBytes(1);
     }
 
     private CreateExprVisitor exprVisitor() {
         return CreateVisitors.expr(sourceFileName);
-    };
+    }
 }

--- a/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/e2e/InstrRegTest.java
+++ b/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/e2e/InstrRegTest.java
@@ -185,4 +185,54 @@ public class InstrRegTest extends AbstractCompilerTest {
                 0xBF, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE
         );
     }
+
+    @Test
+    public void testDisplacementWithMinus() {
+        // ld a, (ix - 5) should be equivalent to ld a, (ix + (-5))
+        // DD 7E FB  (0xFB = -5 as signed byte)
+        compile("ld a, (ix - 5)");
+        assertProgram(0xDD, 0x7E, 0xFB);
+    }
+
+    @Test
+    public void testDisplacementWithMinusIY() {
+        // ld a, (iy - 3) -> FD 7E FD (0xFD = -3 as signed byte)
+        compile("ld a, (iy - 3)");
+        assertProgram(0xFD, 0x7E, 0xFD);
+    }
+
+    @Test
+    public void testDisplacementWithMinusInc() {
+        // inc (ix - 1) -> DD 34 FF
+        compile("inc (ix - 1)");
+        assertProgram(0xDD, 0x34, 0xFF);
+    }
+
+    @Test
+    public void testDisplacementWithMinusRlc() {
+        // rlc (ix - 2) -> DD CB FE 06
+        compile("rlc (ix - 2)");
+        assertProgram(0xDD, 0xCB, 0xFE, 0x06);
+    }
+
+    @Test
+    public void testDisplacementWithMinusLdStore() {
+        // ld (iy - 10), b -> FD 70 F6
+        compile("ld (iy - 10), b");
+        assertProgram(0xFD, 0x70, 0xF6);
+    }
+
+    @Test
+    public void testDisplacementWithMinusLdImmediate() {
+        // ld (ix - 4), 0x42 -> DD 36 FC 42
+        compile("ld (ix - 4), 42h");
+        assertProgram(0xDD, 0x36, 0xFC, 0x42);
+    }
+
+    @Test
+    public void testDisplacementWithPlusStillWorks() {
+        // ld a, (ix + 5) should still work
+        compile("ld a, (ix + 5)");
+        assertProgram(0xDD, 0x7E, 0x05);
+    }
 }

--- a/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/parser/ParseProgramTest.java
+++ b/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/parser/ParseProgramTest.java
@@ -1,0 +1,89 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.compiler.asZ80.parser;
+
+import net.emustudio.emulib.plugins.compiler.SourceCodePosition;
+import net.emustudio.plugins.compiler.asZ80.ast.Program;
+import net.emustudio.plugins.compiler.asZ80.ast.instr.Instr;
+import net.emustudio.plugins.compiler.asZ80.ast.instr.InstrXD;
+import net.emustudio.plugins.compiler.asZ80.ast.expr.ExprNumber;
+import net.emustudio.plugins.compiler.asZ80.ast.expr.ExprUnary;
+import org.junit.Test;
+
+import static net.emustudio.plugins.compiler.asZ80.AsZ80Parser.*;
+import static net.emustudio.plugins.compiler.asZ80.Utils.assertTrees;
+import static net.emustudio.plugins.compiler.asZ80.Utils.parseProgram;
+
+public class ParseProgramTest {
+    private final static SourceCodePosition POSITION = new SourceCodePosition(0, 0, "");
+
+    @Test
+    public void testEmptyProgram() {
+        Program program = parseProgram("");
+        assertTrees(new Program(""), program);
+    }
+
+    @Test
+    public void testSingleInstrNoNewline() {
+        Program program = parseProgram("nop");
+        assertTrees(new Program("").addChild(new Instr(POSITION, OPCODE_NOP, 0, 0, 0)), program);
+    }
+
+    @Test
+    public void testSingleInstrWithNewline() {
+        Program program = parseProgram("nop\n");
+        assertTrees(new Program("").addChild(new Instr(POSITION, OPCODE_NOP, 0, 0, 0)), program);
+    }
+
+    @Test
+    public void testMultipleInstrTrailingNewline() {
+        Program program = parseProgram("nop\nhalt\n");
+        assertTrees(new Program("")
+                        .addChild(new Instr(POSITION, OPCODE_NOP, 0, 0, 0))
+                        .addChild(new Instr(POSITION, OPCODE_HALT, 1, 6, 6)),
+                program);
+    }
+
+    @Test
+    public void testMultipleInstrNoTrailingNewline() {
+        Program program = parseProgram("nop\nhalt");
+        assertTrees(new Program("")
+                        .addChild(new Instr(POSITION, OPCODE_NOP, 0, 0, 0))
+                        .addChild(new Instr(POSITION, OPCODE_HALT, 1, 6, 6)),
+                program);
+    }
+
+    @Test
+    public void testCommentOnly() {
+        Program program = parseProgram("; just a comment");
+        assertTrees(new Program(""), program);
+    }
+
+    @Test
+    public void testEmptyLines() {
+        Program program = parseProgram("\n\n\nnop\n\n");
+        assertTrees(new Program("").addChild(new Instr(POSITION, OPCODE_NOP, 0, 0, 0)), program);
+    }
+
+    @Test
+    public void testDisplacementMinusInParser() {
+        // ld a, (ix - 5) should parse with ExprUnary wrapping the displacement expression
+        Program program = parseProgram("ld a, (ix - 5)");
+        assertTrees(new Program("")
+                        .addChild(new InstrXD(POSITION, OPCODE_LD, 0xDD, 1, 7, 6)
+                                .addChild(new ExprUnary(POSITION, OP_SUBTRACT)
+                                        .addChild(new ExprNumber(POSITION, 5)))),
+                program);
+    }
+
+    @Test
+    public void testDisplacementPlusInParser() {
+        // ld a, (ix + 5) should parse normally (no ExprUnary)
+        Program program = parseProgram("ld a, (ix + 5)");
+        assertTrees(new Program("")
+                        .addChild(new InstrXD(POSITION, OPCODE_LD, 0xDD, 1, 7, 6)
+                                .addChild(new ExprNumber(POSITION, 5))),
+                program);
+    }
+}
+

--- a/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/visitors/CollectExprsInOpcodeVisitorTest.java
+++ b/plugins/compiler/as-z80/src/test/java/net/emustudio/plugins/compiler/asZ80/visitors/CollectExprsInOpcodeVisitorTest.java
@@ -1,0 +1,146 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.plugins.compiler.asZ80.visitors;
+
+import net.emustudio.emulib.plugins.compiler.SourceCodePosition;
+import net.emustudio.plugins.compiler.asZ80.ast.Evaluated;
+import net.emustudio.plugins.compiler.asZ80.ast.Program;
+import net.emustudio.plugins.compiler.asZ80.ast.instr.Instr;
+import net.emustudio.plugins.compiler.asZ80.ast.instr.InstrCB;
+import net.emustudio.plugins.compiler.asZ80.ast.instr.InstrXDCB;
+import net.emustudio.plugins.compiler.asZ80.ast.pseudo.PseudoVar;
+import org.junit.Test;
+
+import static net.emustudio.plugins.compiler.asZ80.AsZ80Parser.*;
+import static net.emustudio.plugins.compiler.asZ80.CompileError.ERROR_VALUE_OUT_OF_BOUNDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CollectExprsInOpcodeVisitorTest {
+    private final static SourceCodePosition POSITION = new SourceCodePosition(0, 0, "");
+
+    @Test
+    public void testRstSetsYFromExpression() {
+        // RST 0x10 => y = 0x10/8 = 2
+        Program program = new Program("");
+        Instr rst = new Instr(POSITION, OPCODE_RST, 3, 0, 7);
+        rst.setSizeBytes(1);
+        rst.addChild(new Evaluated(POSITION, 0x10));
+        program.addChild(rst);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+        // Evaluated child should be removed
+        assertEquals(0, rst.getChildren().size());
+    }
+
+    @Test
+    public void testRstInvalidValueReportsError() {
+        // RST 14 is not in allowed set {0, 8, 16, 24, 32, 40, 48, 56}
+        Program program = new Program("");
+        Instr rst = new Instr(POSITION, OPCODE_RST, 3, 0, 7);
+        rst.setSizeBytes(1);
+        rst.addChild(new Evaluated(POSITION, 14));
+        program.addChild(rst);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasError(ERROR_VALUE_OUT_OF_BOUNDS));
+    }
+
+    @Test
+    public void testCBbitSetsY() {
+        // BIT 5, b => y should be set to 5
+        Program program = new Program("");
+        InstrCB bit = new InstrCB(POSITION, OPCODE_BIT, 0, 0);
+        bit.setSizeBytes(2);
+        bit.addChild(new Evaluated(POSITION, 5));
+        program.addChild(bit);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+        assertEquals(0, bit.getChildren().size());
+    }
+
+    @Test
+    public void testCBresSetsY() {
+        // RES 3, c => y should be set to 3
+        Program program = new Program("");
+        InstrCB res = new InstrCB(POSITION, OPCODE_RES, 0, 1);
+        res.setSizeBytes(2);
+        res.addChild(new Evaluated(POSITION, 3));
+        program.addChild(res);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+        assertEquals(0, res.getChildren().size());
+    }
+
+    @Test
+    public void testCBsetSetsY() {
+        // SET 7, d => y should be set to 7
+        Program program = new Program("");
+        InstrCB set = new InstrCB(POSITION, OPCODE_SET, 0, 2);
+        set.setSizeBytes(2);
+        set.addChild(new Evaluated(POSITION, 7));
+        program.addChild(set);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+        assertEquals(0, set.getChildren().size());
+    }
+
+    @Test
+    public void testXDCBbitSetsY() {
+        // BIT 5, (IX+d) => y should be set to 5
+        Program program = new Program("");
+        InstrXDCB bit = new InstrXDCB(POSITION, OPCODE_BIT, 0xDD, 0, 6);
+        bit.setSizeBytes(4);
+        bit.addChild(new Evaluated(POSITION, 5));
+        bit.addChild(new Evaluated(POSITION, 0x20).setSizeBytes(1));
+        program.addChild(bit);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+        // Only the displacement Evaluated should remain as child
+        assertEquals(1, bit.getChildren().size());
+    }
+
+    @Test
+    public void testXDCBresSetsY() {
+        Program program = new Program("");
+        InstrXDCB res = new InstrXDCB(POSITION, OPCODE_RES, 0xFD, 0, 6);
+        res.setSizeBytes(4);
+        res.addChild(new Evaluated(POSITION, 6));
+        res.addChild(new Evaluated(POSITION, 0x10).setSizeBytes(1));
+        program.addChild(res);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+        assertEquals(1, res.getChildren().size());
+    }
+
+    @Test
+    public void testCBrlcDoesNotSetY() {
+        // RLC b - no bit expression, should not change y
+        Program program = new Program("");
+        InstrCB rlc = new InstrCB(POSITION, OPCODE_RLC, 0, 0);
+        rlc.setSizeBytes(2);
+        program.addChild(rlc);
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        assertTrue(program.env().hasNoErrors());
+    }
+
+    @Test
+    public void testVarNodeIsRemoved() {
+        Program program = new Program("");
+        PseudoVar var = new PseudoVar(POSITION, "x");
+        program.addChild(var);
+        program.addChild(new Instr(POSITION, OPCODE_NOP, 0, 0, 0).setSizeBytes(1));
+
+        new CollectExprsInOpcodeVisitor().visit(program);
+        // var should be removed, only nop remains
+        assertEquals(1, program.getChildren().size());
+    }
+}
+


### PR DESCRIPTION
- Fix: displacement (IX-d)/(IY-d) syntax was rejected
- Fix: rStart rule was misleading; simplify to idiomatic
- Group ~140 redundant parser alternatives into single rules
- Parser grammar reduced from 338 to 197 lines (-42%)
- Simplify lexer CONDITION mode predicates readability
- Extract static HashMap in visitInstr (was per-call alloc)
- CreateInstrVisitor reduced from 631 to 475 lines (-25%)
- Add helper visitDisplacementExpr for minus sign support
- Add CollectExprsInOpcodeVisitorTest (9 new tests)
- Add ParseProgramTest (8 new tests for rStart edge cases)
- Add displacement minus e2e tests in InstrRegTest (7 tests)
- Collapse rRegister/rRegPair/cCondition to single-line rules