### PR TITLE
[#314] Drop EAR line after tape playback ends

### DIFF
--- a/plugins/device/audiotape-player/src/main/java/net/emustudio/plugins/device/audiotape_player/TapePlaybackImpl.java
+++ b/plugins/device/audiotape-player/src/main/java/net/emustudio/plugins/device/audiotape_player/TapePlaybackImpl.java
@@ -50,6 +50,9 @@ public class TapePlaybackImpl implements Loader.TapePlayback, CPUContext.PassedC
     private long currentTstates;
     private boolean pulseUp;
     private boolean lastIntervalNeedsClosingEdge;
+    // Last value driven onto the EAR line. Needed as a generic fallback when the playback target
+    // is not the Spectrum bus and the line must be explicitly driven low on stop/unload.
+    private byte lastLineValue;
 
     private volatile boolean playing;
     private long playingTstates;
@@ -88,6 +91,7 @@ public class TapePlaybackImpl implements Loader.TapePlayback, CPUContext.PassedC
         currentTstates = 1;
         pulseUp = false;
         lastIntervalNeedsClosingEdge = false;
+        releaseEarLine();
         resetPlaybackMetrics();
         updatePlaybackProgress(0);
         schedulePulse(millisToTstates(FILE_START_PAUSE_MS), "PAUSE", "", false);
@@ -180,9 +184,15 @@ public class TapePlaybackImpl implements Loader.TapePlayback, CPUContext.PassedC
 
     @Override
     public void onStateChange(TapePlaybackController.CassetteState state) {
-        if ((state == TapePlaybackController.CassetteState.UNLOADED)
+        if (state == TapePlaybackController.CassetteState.STOPPED) {
+            // Release the line only after the controller reports STOPPED so the final closing
+            // edge remains visible through the end of playback without synthesizing an extra
+            // writeData(0) pulse on the timing path.
+            releaseEarLine();
+        } else if ((state == TapePlaybackController.CassetteState.UNLOADED)
                 || (state == TapePlaybackController.CassetteState.CLOSED)) {
             resetPlaybackMetrics();
+            releaseEarLine();
         }
         Optional.ofNullable(gui.get()).ifPresent(g -> g.setCassetteState(state));
     }
@@ -494,7 +504,27 @@ public class TapePlaybackImpl implements Loader.TapePlayback, CPUContext.PassedC
     }
 
     private void writeLineValue(byte value) {
+        lastLineValue = value;
         lineIn.writeData(value);
+    }
+
+    private void releaseEarLine() {
+        if (invokeOptionalZeroArgVoidMethod("releaseTapeEarLine")) {
+            lastLineValue = 0;
+        } else if (lastLineValue != 0) {
+            writeLineValue((byte) 0);
+        }
+    }
+
+    private boolean invokeOptionalZeroArgVoidMethod(String methodName) {
+        try {
+            lineIn.getClass().getMethod(methodName).invoke(lineIn);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Could not invoke " + methodName + " on tape line target", e);
+        }
     }
 
     private void ensureClosingEdgeAtFileEnd() {

--- a/plugins/device/audiotape-player/src/test/java/net/emustudio/plugins/device/audiotape_player/TapePlaybackImplTest.java
+++ b/plugins/device/audiotape-player/src/test/java/net/emustudio/plugins/device/audiotape_player/TapePlaybackImplTest.java
@@ -49,6 +49,7 @@ public class TapePlaybackImplTest {
             playback.passedCycles(tstatesPerCall);
         }
         playThread.join(5000);
+        playback.passedCycles(1);
     }
 
     private Thread startPlaybackAsync() throws InterruptedException {
@@ -206,9 +207,10 @@ public class TapePlaybackImplTest {
         Thread playThread = startPlaybackAsync();
         playback.passedCycles(Integer.MAX_VALUE);
         playThread.join(2000);
+        playback.passedCycles(1);
 
         assertFalse("Playback should finish in one drain", playThread.isAlive());
-        // 1 PAUSE + 3 bytes * 16 pulses + EOF closing edge = 50 edges
+        // 1 PAUSE + 3 bytes * 16 pulses + EOF closing edge (=1) = 50
         assertEquals(50, writtenData.size());
         assertEquals(100, getLastReportedProgress());
     }
@@ -255,7 +257,7 @@ public class TapePlaybackImplTest {
 
         drainPulses(100, 100_000);
 
-        // 1 (PAUSE) + 16 (data byte) + EOF closing edge = 18 pulses
+        // 1 (PAUSE) + 16 (data byte) + EOF closing edge (=1) = 18
         assertEquals(18, writtenData.size());
     }
 
@@ -327,6 +329,8 @@ public class TapePlaybackImplTest {
         playThread.join(1000);
 
         assertFalse("Turbo playback should finish after draining all overdue pulses", playThread.isAlive());
+        playback.passedCycles(1);
+        // 1 PAUSE + 2 pilot + sync1 + sync2 + 16 data + 1 trailing pause (last=1)
         assertEquals(22, writtenData.size());
         assertEquals(100, getLastReportedProgress());
     }
@@ -436,7 +440,7 @@ public class TapePlaybackImplTest {
 
         drainPulses(200, 100_000);
 
-        // 1 (PAUSE) + 48 (3 bytes) + EOF closing edge = 50
+        // 1 (PAUSE) + 48 (3 bytes) + EOF closing edge (=1) = 50
         assertEquals(50, writtenData.size());
     }
 
@@ -447,7 +451,7 @@ public class TapePlaybackImplTest {
 
         drainPulses(100, 100_000);
 
-        // 1 (PAUSE) + 16 (flag byte) + EOF closing edge = 18
+        // 1 (PAUSE) + 16 (flag byte) + EOF closing edge (=1) = 18
         assertEquals(18, writtenData.size());
     }
 
@@ -519,5 +523,63 @@ public class TapePlaybackImplTest {
         long tstates = getCurrentTstates();
         // 2000 ms * max(1, 0) kHz = 2000 T-states + initial 1
         assertEquals(2001L, tstates);
+    }
+
+    @Test
+    public void testSpectrumBusReleasesEarLineOnStoppedState() throws InterruptedException {
+        RecordingLineIn spectrumBus = new RecordingLineIn();
+        playback = new TapePlaybackImpl(spectrumBus, () -> 1);
+        playback.onFileStart();
+        playback.onBlockData(new byte[]{(byte) 0xFF}); // final closing edge drives line high
+        long totalTstates = getCurrentTstates();
+
+        Thread playThread = startPlaybackAsync();
+        playback.passedCycles(totalTstates);
+        playThread.join(1000);
+
+        assertFalse("Playback should finish once all scheduled T-states have elapsed", playThread.isAlive());
+        assertEquals("Final closing edge must stay visible until controller reports STOPPED",
+                (byte) 1, (byte) spectrumBus.readData());
+
+        playback.onStateChange(TapePlaybackController.CassetteState.STOPPED);
+
+        assertEquals("STOPPED must release the Spectrum EAR line to idle low",
+                (byte) 0, (byte) spectrumBus.readData());
+    }
+
+    @Test
+    public void testEarLineNotReclearedWhenAlreadyZero() throws InterruptedException {
+        // If the closing edge already left the line low, no extra write must be emitted.
+        playback.onFileStart();
+        playback.onPulseSequence(new int[]{500}); // pause(0) + pulse(1) + closing(0)
+        drainPulses(100, 100_000);
+
+        assertEquals(3, writtenData.size());
+        assertEquals((byte) 0, (byte) writtenData.get(writtenData.size() - 1));
+    }
+
+    private static final class RecordingLineIn implements DeviceContext<Byte> {
+        private byte value;
+        private boolean released = true;
+
+        @Override
+        public Byte readData() {
+            return released ? (byte) 0 : value;
+        }
+
+        @Override
+        public void writeData(Byte value) {
+            this.value = value;
+            this.released = false;
+        }
+
+        @Override
+        public Class<Byte> getDataType() {
+            return Byte.class;
+        }
+
+        public void releaseTapeEarLine() {
+            this.released = true;
+        }
     }
 }

--- a/plugins/device/zxspectrum-bus/src/main/java/net/emustudio/plugins/device/zxspectrum/bus/ZxSpectrumBusImpl.java
+++ b/plugins/device/zxspectrum-bus/src/main/java/net/emustudio/plugins/device/zxspectrum/bus/ZxSpectrumBusImpl.java
@@ -73,7 +73,11 @@ public class ZxSpectrumBusImpl extends AbstractMemoryContext<Byte> implements Zx
 
     private ContextZ80 cpu;
     private MemoryContext<Byte> memory;
-    private volatile byte busData; // data on the bus
+    // Last tape bit driven onto the bus by the cassette player.
+    private volatile byte busData;
+    // True only while the tape deck actively drives EAR. When false, port 0xFE bit 6 must read
+    // idle low without injecting another tape edge into the timing stream.
+    private volatile boolean tapeEarLineDriven;
 
     private long frameCycles;
 
@@ -95,6 +99,8 @@ public class ZxSpectrumBusImpl extends AbstractMemoryContext<Byte> implements Zx
     public void initialize(ContextZ80 cpu, MemoryContext<Byte> memory) {
         this.cpu = Objects.requireNonNull(cpu);
         this.memory = Objects.requireNonNull(memory);
+        this.busData = 0;
+        this.tapeEarLineDriven = false;
 
         // ZX Spectrum ULA holds INT low for 32 T-states at each frame boundary
         cpu.setInterruptDuration(timing.interruptTstates);
@@ -213,12 +219,17 @@ public class ZxSpectrumBusImpl extends AbstractMemoryContext<Byte> implements Zx
 
     @Override
     public Byte readData() {
-        return busData;
+        return tapeEarLineDriven ? busData : (byte) 0;
     }
 
     @Override
     public void writeData(Byte data) {
         this.busData = data;
+        this.tapeEarLineDriven = true;
+    }
+
+    public void releaseTapeEarLine() {
+        this.tapeEarLineDriven = false;
     }
 
     @Override

--- a/plugins/device/zxspectrum-bus/src/test/java/net/emustudio/plugins/device/zxspectrum/bus/ZxSpectrumBusImplTest.java
+++ b/plugins/device/zxspectrum-bus/src/test/java/net/emustudio/plugins/device/zxspectrum/bus/ZxSpectrumBusImplTest.java
@@ -358,7 +358,17 @@ public class ZxSpectrumBusImplTest {
         assertEquals((byte) 0xFF, (byte) bus.readData());
     }
 
-    // ========== Interrupt delegation tests ==========
+    @Test
+    public void testReleaseTapeEarLineMakesBusReadIdleLow() {
+        ZxSpectrumBusImpl bus = new ZxSpectrumBusImpl();
+
+        bus.writeData((byte) 0x01);
+        assertEquals((byte) 0x01, (byte) bus.readData());
+
+        bus.releaseTapeEarLine();
+
+        assertEquals((byte) 0x00, (byte) bus.readData());
+    }
 
     @Test
     public void testSignalNonMaskableInterruptDelegatesToCpu() {


### PR DESCRIPTION
- clear EAR to idle when playback or unload stops driving tape
- avoid duplicate zero writes when line already idle
- extend audiotape tests for tape-end EAR behavior