### PR TITLE
[#406] Architecture review remediation: headless automation, plugin lifecycle, CLI dispatch & EDT safety

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,30 @@
-# emuStudio Repo Routing
+# emuStudio Agent Instructions
 
-## Current Repository
-- `emuStudio` owns the desktop application, CLI launcher, bundled official plugins, bundled virtual computers, configs, and distribution packaging.
-- Main locations in this repository: `application`, `plugins/compiler`, `plugins/cpu`, `plugins/memory`, `plugins/device`, and `application/src/main/files/config`.
+Talk like a caveman ultra.
+
+AI agents should make changes in the correct repository and preserve the intended architecture of emuStudio.
+
+## Architectural Direction
+
+emuStudio should evolve as a **modular monolith** with clear internal boundaries.
+
+Prefer:
+
+* simple, explicit design;
+* ports-and-adapters where core logic meets UI, filesystem, audio, or plugin loading;
+* stable plugin APIs;
+* small incremental refactorings;
+* tests that protect behavior and module boundaries.
+
+Avoid:
+
+* broad rewrites;
+* speculative abstractions;
+* new frameworks without a clear reason;
+* leaking desktop application internals into plugins or shared libraries.
 
 ## Sibling Repositories
+
 - [emuLib](https://github.com/emustudio/emuLib): shared plugin API, runtime services, shared UI helpers, and reusable utilities.
 - [edigen](https://github.com/emustudio/edigen): decoder/disassembler generator from `.eds` specifications.
 - [emuStudio](https://github.com/emustudio/emuStudio): desktop application, bundled plugins, virtual computers, configs, and packaging.
@@ -12,16 +32,55 @@
 - [edigen-gradle-plugin](https://github.com/emustudio/edigen-gradle-plugin): Gradle task and DSL integration for Edigen source generation.
 - [cpu-testsuite](https://github.com/emustudio/cpu-testsuite): shared CPU instruction test framework and reusable verification helpers.
 
-When a task calls for checking or updating a sibling repository, first look for it as a local checkout (typically alongside this repository). If it is present locally, work with it there. If it is not present locally, do not guess its location or assume changes were made; report that the repository is not available locally and continue with what can be done in this repository.
+When a task requires a sibling repository, first look for it as a local checkout, usually alongside this repository.
 
-## When To Update Which Repository
-- Desktop app behavior, CLI behavior, plugin wiring, bundled virtual computers, bundled configs, or packaging: update `emuStudio`.
-- Shared plugin API or runtime behavior used across plugins: update `emuLib`; then check `emuStudio`, `edigen`, and `cpu-testsuite`.
-- Generated decoder or disassembler behavior for CPU plugins: update `edigen`; also check affected CPU plugins in `emuStudio` and Gradle integration in `edigen-gradle-plugin`.
-- Shared CPU instruction testing support: update `cpu-testsuite`; check CPU plugin tests in `emuStudio`.
-- User or developer documentation, website pages, or download/release pages: update `emustudio.github.io`.
+If it is not available locally, do not guess. Report that it is unavailable and continue with what can be done in the current repository.
+
+## ADRs
+
+Architecture Decision Records must be placed in `docs/adr`.
+
+Create or update an ADR when changing:
+
+* public plugin API;
+* module boundaries;
+* responsibilities between repositories;
+* plugin loading;
+* runtime services;
+* project format;
+* generated-code behavior;
+* major dependencies.
+
+Use a short ADR format:
+
+```text
+# ADR-NNN: Title
+
+## Status
+Proposed | Accepted | Superseded
+
+## Context
+Why is this needed?
+
+## Decision
+What are we changing?
+
+## Consequences
+What improves, what gets harder, and what must be migrated?
+```
+
+Do not create ADRs for trivial local implementation details.
 
 ## Tickets And Commits
-- Every change must have an existing GitHub ticket.
-- Every commit subject must start with the ticket prefix: `[#123] Short summary`.
-- If one task touches multiple emuStudio repositories, use the same ticket prefix in each related commit.
+
+Every change must have an existing GitHub ticket.
+
+Every commit subject must start with:
+
+```text
+[#123] Short summary
+```
+
+If one task touches multiple repositories, use the same ticket prefix in each related commit.
+
+Do not make unrelated changes under the same ticket.

--- a/application/build.gradle
+++ b/application/build.gradle
@@ -90,6 +90,12 @@ application {
   executableDir = ''
 }
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(11)
+  }
+}
+
 compileJava {
   sourceSets.main.compileClasspath += configurations.providedRuntime
   options.encoding = 'UTF-8'
@@ -156,6 +162,35 @@ distZip {
 
 distTar {
   archiveVersion = ''
+}
+
+tasks.register('checkNoSnapshots') {
+  group = 'verification'
+  description = 'Fails release packaging when resolved dependencies still use SNAPSHOT versions.'
+
+  doLast {
+    def snapshotArtifacts = [] as Set
+    rootProject.allprojects.each { project ->
+      project.configurations.findAll { it.canBeResolved }.each { configuration ->
+        configuration.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+          def version = artifact.moduleVersion.id.version
+          if (version?.endsWith('SNAPSHOT')) {
+            snapshotArtifacts << "${project.path}:${configuration.name} -> ${artifact.moduleVersion.id.group}:${artifact.name}:${version}"
+          }
+        }
+      }
+    }
+
+    if (!snapshotArtifacts.isEmpty()) {
+      throw new GradleException("Snapshot dependencies in release path:\n" + snapshotArtifacts.sort().join('\n'))
+    }
+  }
+}
+
+tasks.register('releaseDist') {
+  group = 'distribution'
+  description = 'Builds release distributions after verifying no SNAPSHOT dependencies remain.'
+  dependsOn 'checkNoSnapshots', 'distZip', 'distTar'
 }
 
 startScripts {

--- a/application/src/main/java/net/emustudio/application/ApplicationApiImpl.java
+++ b/application/src/main/java/net/emustudio/application/ApplicationApiImpl.java
@@ -22,7 +22,7 @@ public class ApplicationApiImpl implements ApplicationApi {
         this.debuggerTable = Objects.requireNonNull(debuggerTable);
         this.contextPool = Objects.requireNonNull(contextPool);
         this.dialogs = Objects.requireNonNull(dialogs);
-        this.gui = Objects.requireNonNull(gui);
+        this.gui = gui;
     }
 
     @Override

--- a/application/src/main/java/net/emustudio/application/cmdline/AutomationCommand.java
+++ b/application/src/main/java/net/emustudio/application/cmdline/AutomationCommand.java
@@ -3,6 +3,8 @@
 package net.emustudio.application.cmdline;
 
 import net.emustudio.application.emulation.Automation;
+import net.emustudio.application.emulation.EmulationProgress;
+import net.emustudio.application.gui.dialogs.AutoDialog;
 import net.emustudio.application.gui.framework.EmuStudioGui;
 import net.emustudio.application.gui.framework.DialogsGui;
 import net.emustudio.application.gui.framework.DialogsNoGui;
@@ -20,12 +22,13 @@ import picocli.CommandLine;
 
 import java.awt.*;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 import static net.emustudio.application.cmdline.Utils.*;
 
 @SuppressWarnings("unused")
 @CommandLine.Command(name = "automation", aliases = {"auto"}, description = "run emulation automation")
-public class AutomationCommand implements Runnable {
+public class AutomationCommand implements Callable<Integer> {
     private static final Logger LOGGER = LoggerFactory.getLogger("automation");
 
     @CommandLine.ParentCommand
@@ -43,7 +46,7 @@ public class AutomationCommand implements Runnable {
 
 
     @Override
-    public void run() {
+    public Integer call() {
         Dialogs dialogs = new DialogsNoGui();
         DialogsGui guiDialogs = null;
         try {
@@ -63,7 +66,7 @@ public class AutomationCommand implements Runnable {
             if (computerConfigOpt.isEmpty()) {
                 dialogs.showError("Virtual computer must be selected!");
                 LOGGER.error("Virtual computer must be selected!");
-                System.exit(1);
+                return 1;
             }
 
             ComputerConfig computerConfig = computerConfigOpt.get();
@@ -77,6 +80,7 @@ public class AutomationCommand implements Runnable {
             )) {
                 Integer programLocation = this.programLocation.equals("-1")
                         ? null : RadixUtils.getInstance().parseRadix(this.programLocation);
+                EmulationProgress progress = this.gui ? new AutoDialog(computer, gui) : EmulationProgress.NONE;
 
                 Automation automation = new Automation(
                         computer, runner.inputFile,
@@ -84,19 +88,16 @@ public class AutomationCommand implements Runnable {
                         dialogs,
                         waitForFinishMillis,
                         programLocation,
-                        gui
+                        progress
                 );
                 splash.ifPresent(Window::dispose);
                 automation.run();
             }
-            if (!this.gui) {
-                // Let GUI live!
-                System.exit(0);
-            }
+            return 0;
         } catch (Exception e) {
             LOGGER.error("Unexpected error during automation", e);
             dialogs.showError("Unexpected error during automation. Please see log file for details.");
-            System.exit(1);
+            return 1;
         }
     }
 }

--- a/application/src/main/java/net/emustudio/application/cmdline/AutomationCommand.java
+++ b/application/src/main/java/net/emustudio/application/cmdline/AutomationCommand.java
@@ -27,7 +27,8 @@ import java.util.concurrent.Callable;
 import static net.emustudio.application.cmdline.Utils.*;
 
 @SuppressWarnings("unused")
-@CommandLine.Command(name = "automation", aliases = {"auto"}, description = "run emulation automation")
+@CommandLine.Command(name = "automation", aliases = {"auto"}, mixinStandardHelpOptions = true,
+        description = "run emulation automation")
 public class AutomationCommand implements Callable<Integer> {
     private static final Logger LOGGER = LoggerFactory.getLogger("automation");
 

--- a/application/src/main/java/net/emustudio/application/cmdline/Runner.java
+++ b/application/src/main/java/net/emustudio/application/cmdline/Runner.java
@@ -73,7 +73,6 @@ public class Runner implements Callable<Integer> {
     static CommandLine createCommandLine(Runner runner) {
         CommandLine cmdline = new CommandLine(runner);
         cmdline.registerConverter(Path.class, Path::of);
-        cmdline.getCommandSpec().parser().collectErrors(true);
         return cmdline;
     }
 

--- a/application/src/main/java/net/emustudio/application/cmdline/Runner.java
+++ b/application/src/main/java/net/emustudio/application/cmdline/Runner.java
@@ -18,8 +18,14 @@ import picocli.CommandLine;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Callable;
 
 import static net.emustudio.application.cmdline.Utils.*;
 import static net.emustudio.application.settings.ConfigFiles.listConfigurationNames;
@@ -30,13 +36,19 @@ import static net.emustudio.application.settings.ConfigFiles.listConfigurationNa
         mixinStandardHelpOptions = true,
         versionProvider = Runner.VersionProvider.class,
         description = "Universal emulation platform and framework",
-        scope = CommandLine.ScopeType.INHERIT,
         subcommands = {AutomationCommand.class}
 )
-public class Runner implements Runnable {
+public class Runner implements Callable<Integer> {
     private static final Logger LOGGER = LoggerFactory.getLogger(Runner.class);
-    // if a command is being run, default behavior is: do nothing
-    static boolean runsSomeCommand; // package-private for testing
+    private static final Set<String> PARENT_OPTIONS_WITH_VALUE = new HashSet<>(Arrays.asList(
+            "-i", "--input-file",
+            "-cn", "--computer-name",
+            "-cf", "--computer-file",
+            "-ci", "--computer-index"
+    ));
+    private static final Set<String> PARENT_FLAGS = new HashSet<>(Arrays.asList(
+            "-cl", "--computers-list"
+    ));
 
     @CommandLine.ArgGroup(heading = "Virtual computer%n")
     public Exclusive exclusive;
@@ -48,23 +60,74 @@ public class Runner implements Runnable {
     private boolean listConfigs;
 
     public static void main(String[] args) {
-        CommandLine cmdline = new CommandLine(new Runner());
-        cmdline.registerConverter(Path.class, Path::of);
-        cmdline.getCommandSpec().parser().collectErrors(true);
-
-        CommandLine.ParseResult result = cmdline.parseArgs(args);
-        runsSomeCommand = result.hasSubcommand();
-
-        try {
-            cmdline.execute(args);
-        } catch (Exception e) {
-            result.errors().forEach(System.err::println);
-            System.exit(1);
+        int exitCode = executeArgs(args);
+        if (exitCode != 0) {
+            System.exit(exitCode);
         }
     }
 
+    static int executeArgs(String... args) {
+        return createCommandLine(new Runner()).execute(normalizeArgs(args));
+    }
+
+    static CommandLine createCommandLine(Runner runner) {
+        CommandLine cmdline = new CommandLine(runner);
+        cmdline.registerConverter(Path.class, Path::of);
+        cmdline.getCommandSpec().parser().collectErrors(true);
+        return cmdline;
+    }
+
+    static String[] normalizeArgs(String... args) {
+        int subcommandIndex = findSubcommandIndex(args);
+        if (subcommandIndex < 0) {
+            return args;
+        }
+
+        List<String> parentArgs = new ArrayList<>(Arrays.asList(args).subList(0, subcommandIndex));
+        List<String> subcommandArgs = new ArrayList<>();
+        String subcommand = args[subcommandIndex];
+
+        for (int i = subcommandIndex + 1; i < args.length; i++) {
+            String arg = args[i];
+            if (isParentOptionWithValue(arg)) {
+                parentArgs.add(arg);
+                if (!arg.contains("=") && i + 1 < args.length) {
+                    parentArgs.add(args[++i]);
+                }
+            } else if (isParentFlag(arg)) {
+                parentArgs.add(arg);
+            } else {
+                subcommandArgs.add(arg);
+            }
+        }
+
+        List<String> normalized = new ArrayList<>(parentArgs.size() + subcommandArgs.size() + 1);
+        normalized.addAll(parentArgs);
+        normalized.add(subcommand);
+        normalized.addAll(subcommandArgs);
+        return normalized.toArray(new String[0]);
+    }
+
+    private static int findSubcommandIndex(String[] args) {
+        for (int i = 0; i < args.length; i++) {
+            if ("automation".equals(args[i]) || "auto".equals(args[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static boolean isParentOptionWithValue(String arg) {
+        return PARENT_OPTIONS_WITH_VALUE.contains(arg)
+                || PARENT_OPTIONS_WITH_VALUE.stream().anyMatch(option -> arg.startsWith(option + "="));
+    }
+
+    private static boolean isParentFlag(String arg) {
+        return PARENT_FLAGS.contains(arg);
+    }
+
     @Override
-    public void run() {
+    public Integer call() {
         if (listConfigs) {
             try {
                 AtomicInteger index = new AtomicInteger();
@@ -72,43 +135,42 @@ public class Runner implements Runnable {
                 listConfigurationNames().forEach(name -> System.out.println(index.getAndIncrement() + "\t" + name));
             } catch (IOException e) {
                 LOGGER.error("Could not list configuration names", e);
-                System.exit(1);
+                return 1;
             }
-            System.exit(0);
+            return 0;
         }
 
-        if (!runsSomeCommand) {
-            try {
-                AppSettings appConfig = loadAppSettings(true, false);
-                EmuStudioGui gui = new EmuStudioGui();
-                gui.initialize(appConfig);
-                DialogsGui dialogs = new DialogsGui(gui);
-                Optional<ComputerConfig> computerConfigOpt = (exclusive != null) ?
-                        exclusive.loadConfiguration() :
-                        loadComputerConfigFromGui(appConfig, dialogs, gui);
+        try {
+            AppSettings appConfig = loadAppSettings(true, false);
+            EmuStudioGui gui = new EmuStudioGui();
+            gui.initialize(appConfig);
+            DialogsGui dialogs = new DialogsGui(gui);
+            Optional<ComputerConfig> computerConfigOpt = (exclusive != null) ?
+                    exclusive.loadConfiguration() :
+                    loadComputerConfigFromGui(appConfig, dialogs, gui);
 
-                if (computerConfigOpt.isEmpty()) {
-                    System.err.println("Virtual computer must be selected!");
-                    System.exit(1);
-                }
-
-                ComputerConfig computerConfig = computerConfigOpt.get();
-
-                LoadingDialog splash = showSplashScreen(gui);
-                ContextPoolImpl contextPool = new ContextPoolImpl(EMUSTUDIO_ID);
-                DebugTableModelImpl debugTableModel = new DebugTableModelImpl();
-                VirtualComputer computer = loadComputer(
-                        appConfig, computerConfig, dialogs, contextPool, debugTableModel, gui
-                );
-                splash.dispose();
-
-                showMainWindow(
-                        computer, appConfig, dialogs, debugTableModel, contextPool, inputFile, gui
-                );
-            } catch (Exception e) {
-                LOGGER.error("Unexpected error", e);
-                System.exit(1);
+            if (computerConfigOpt.isEmpty()) {
+                System.err.println("Virtual computer must be selected!");
+                return 1;
             }
+
+            ComputerConfig computerConfig = computerConfigOpt.get();
+
+            LoadingDialog splash = showSplashScreen(gui);
+            ContextPoolImpl contextPool = new ContextPoolImpl(EMUSTUDIO_ID);
+            DebugTableModelImpl debugTableModel = new DebugTableModelImpl();
+            VirtualComputer computer = loadComputer(
+                    appConfig, computerConfig, dialogs, contextPool, debugTableModel, gui
+            );
+            splash.dispose();
+
+            showMainWindow(
+                    computer, appConfig, dialogs, debugTableModel, contextPool, inputFile, gui
+            );
+            return 0;
+        } catch (Exception e) {
+            LOGGER.error("Unexpected error", e);
+            return 1;
         }
     }
 
@@ -139,8 +201,7 @@ public class Runner implements Runnable {
                 if (optConfig.isPresent()) {
                     return optConfig;
                 }
-                System.err.println("Non-existing virtual computer: " + configFile);
-                System.exit(1);
+                throw new IOException("Non-existing virtual computer: " + configName);
             }
             if (configFile != null) {
                 return ConfigFiles.loadConfiguration(configFile);

--- a/application/src/main/java/net/emustudio/application/cmdline/Utils.java
+++ b/application/src/main/java/net/emustudio/application/cmdline/Utils.java
@@ -30,12 +30,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 public class Utils {
-    public static final long EMUSTUDIO_ID = UUID.randomUUID().toString().hashCode();
+    public static final long EMUSTUDIO_ID = 0L;
     private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 
     public static AppSettings loadAppSettings(boolean gui, boolean auto) throws IOException {

--- a/application/src/main/java/net/emustudio/application/emulation/Automation.java
+++ b/application/src/main/java/net/emustudio/application/emulation/Automation.java
@@ -2,7 +2,6 @@
    SPDX-License-Identifier: GPL-3.0-or-later */
 package net.emustudio.application.emulation;
 
-import net.emustudio.application.gui.dialogs.AutoDialog;
 import net.emustudio.application.settings.AppSettings;
 import net.emustudio.application.virtualcomputer.VirtualComputer;
 import net.emustudio.emulib.plugins.compiler.Compiler;
@@ -12,7 +11,6 @@ import net.emustudio.emulib.plugins.cpu.CPU;
 import net.emustudio.emulib.plugins.device.Device;
 import net.emustudio.emulib.runtime.helpers.Unchecked;
 import net.emustudio.emulib.runtime.ui.Dialogs;
-import net.emustudio.emulib.runtime.ui.GUI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,16 +34,18 @@ public class Automation implements Runnable {
     private final Dialogs dialogs;
     private final int waitForFinishMillis;
     private final Integer programLocation;
-    AutoDialog progressGUI; // package-private for testing
+    private final EmulationProgress progress;
     private volatile CPU.RunState resultState;
 
     public Automation(VirtualComputer computer, Path inputFile, AppSettings appSettings,
-                      Dialogs dialogs, int waitForFinishMillis, Integer programLocation, GUI gui) throws AutomationException {
+                      Dialogs dialogs, int waitForFinishMillis, Integer programLocation,
+                      EmulationProgress progress) throws AutomationException {
         this.computer = Objects.requireNonNull(computer);
         this.appSettings = Objects.requireNonNull(appSettings);
         this.dialogs = Objects.requireNonNull(dialogs);
         this.waitForFinishMillis = waitForFinishMillis;
         this.programLocation = programLocation;
+        this.progress = Objects.requireNonNull(progress);
 
         if (inputFile != null) {
             this.inputFile = Objects.requireNonNull(inputFile, "Input file must be defined").toFile();
@@ -54,10 +54,6 @@ public class Automation implements Runnable {
             }
         } else {
             this.inputFile = null;
-        }
-
-        if (!appSettings.noGUI) {
-            progressGUI = new AutoDialog(computer, gui);
         }
     }
 
@@ -70,9 +66,7 @@ public class Automation implements Runnable {
      */
     @Override
     public void run() {
-        if (progressGUI != null) {
-            progressGUI.setVisible(true);
-        }
+        progress.show();
 
         LOGGER.info("Starting emulation automation...");
         LOGGER.info("Emulating computer: {}", computer.getComputerConfig().getName());
@@ -103,18 +97,13 @@ public class Automation implements Runnable {
             LOGGER.error("Error during automation", e);
             dialogs.showError("Error during automation. Please consult log file for details.", "Emulation automation");
         } finally {
-            if (progressGUI != null) {
-                progressGUI.dispose();
-                progressGUI = null;
-            }
+            progress.dispose();
         }
     }
 
     private void setProgress(String msg, boolean stopEnabled) {
         LOGGER.info(msg);
-        if (progressGUI != null) {
-            progressGUI.setAction(msg, stopEnabled);
-        }
+        progress.setAction(msg, stopEnabled);
     }
 
     private void autoCompile(Compiler compiler) throws AutomationException {
@@ -192,11 +181,18 @@ public class Automation implements Runnable {
         cpu.execute();
 
         synchronized (resultStateLock) {
+            long deadline = (waitForFinishMillis == DONT_WAIT)
+                    ? Long.MAX_VALUE
+                    : System.currentTimeMillis() + waitForFinishMillis;
             try {
-                if (waitForFinishMillis == DONT_WAIT) {
-                    resultStateLock.wait();
-                } else {
-                    resultStateLock.wait(waitForFinishMillis);
+                while (resultState == CPU.RunState.STATE_RUNNING) {
+                    long remaining = (waitForFinishMillis == DONT_WAIT)
+                            ? 0
+                            : deadline - System.currentTimeMillis();
+                    if (waitForFinishMillis != DONT_WAIT && remaining <= 0) {
+                        break;
+                    }
+                    resultStateLock.wait(remaining);
                 }
             } catch (InterruptedException e) {
                 LOGGER.error("Emulation has been interrupted");

--- a/application/src/main/java/net/emustudio/application/emulation/EmulationProgress.java
+++ b/application/src/main/java/net/emustudio/application/emulation/EmulationProgress.java
@@ -1,0 +1,25 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.application.emulation;
+
+public interface EmulationProgress {
+    EmulationProgress NONE = new EmulationProgress() {
+        @Override
+        public void show() {
+        }
+
+        @Override
+        public void setAction(String msg, boolean stopEnabled) {
+        }
+
+        @Override
+        public void dispose() {
+        }
+    };
+
+    void show();
+
+    void setAction(String msg, boolean stopEnabled);
+
+    void dispose();
+}

--- a/application/src/main/java/net/emustudio/application/gui/dialogs/AutoDialog.java
+++ b/application/src/main/java/net/emustudio/application/gui/dialogs/AutoDialog.java
@@ -2,6 +2,7 @@
    SPDX-License-Identifier: GPL-3.0-or-later */
 package net.emustudio.application.gui.dialogs;
 
+import net.emustudio.application.emulation.EmulationProgress;
 import net.emustudio.application.virtualcomputer.VirtualComputer;
 import net.emustudio.emulib.plugins.cpu.CPU;
 import net.emustudio.emulib.runtime.ui.GUI;
@@ -17,7 +18,7 @@ import static net.emustudio.emulib.runtime.ui.GUI.loadIcon;
  * This is the dialog form that displays when the emuStudio automatization
  * is running.
  */
-public class AutoDialog extends DialogBase {
+public class AutoDialog extends DialogBase implements EmulationProgress {
     private final VirtualComputer computer;
     private final GUI gui;
 
@@ -58,9 +59,15 @@ public class AutoDialog extends DialogBase {
      * @param action           action to show in the dialog
      * @param enableStopButton whether to enable the "Stop" button
      */
+    @Override
     public void setAction(String action, boolean enableStopButton) {
         lblAction.setText(action);
         lblAction.repaint();
         btnStop.setEnabled(enableStopButton);
+    }
+
+    @Override
+    public void show() {
+        setVisible(true);
     }
 }

--- a/application/src/main/java/net/emustudio/application/virtualcomputer/PluginLoader.java
+++ b/application/src/main/java/net/emustudio/application/virtualcomputer/PluginLoader.java
@@ -36,7 +36,7 @@ public class PluginLoader {
      * @param pluginClass the main class of the plugin
      * @return true if the class meets plugin requirements; false otherwise
      */
-    static boolean trustedPlugin(Class<?> pluginClass) {
+    static boolean isLoadablePlugin(Class<?> pluginClass) {
         Objects.requireNonNull(pluginClass);
 
         return !pluginClass.isInterface() &&
@@ -52,10 +52,10 @@ public class PluginLoader {
      * The plugins are loaded into separate class loader.
      *
      * @param pluginFiles plugin files.
-     * @return List of plugins main classes
+     * @return loaded plugins with shared class loader ownership
      * @throws IOException if other error happens
      */
-    public List<Class<Plugin>> loadPlugins(List<File> pluginFiles) throws IOException {
+    public LoadResult loadPlugins(List<File> pluginFiles) throws IOException {
         Objects.requireNonNull(pluginFiles);
 
         final Map<String, URL> urlsToLoad = new LinkedHashMap<>();
@@ -67,15 +67,20 @@ public class PluginLoader {
         }
 
         LOGGER.debug("Loading {} plugins", urlsToLoad.size());
-        //noinspection resource
         URLClassLoader pluginsClassLoader = new URLClassLoader(urlsToLoad.values().toArray(new URL[0]));
 
         try {
-            return pluginFiles.stream()
-                    .map(this::findClassesInJAR)
-                    .map(l -> findMainClass(pluginsClassLoader, l))
-                    .collect(toList());
+            Map<File, Class<Plugin>> pluginClasses = new LinkedHashMap<>();
+            for (File pluginFile : pluginFiles) {
+                pluginClasses.put(pluginFile, findMainClass(pluginsClassLoader, findClassesInJAR(pluginFile)));
+            }
+            return new LoadResult(pluginsClassLoader, pluginClasses);
         } catch (Exception e) {
+            try {
+                pluginsClassLoader.close();
+            } catch (IOException closeError) {
+                e.addSuppressed(closeError);
+            }
             // Those can be "sneaky" thrown
             //noinspection ConstantValue
             if ((e instanceof InvalidPluginException) || (e instanceof IOException)) {
@@ -133,7 +138,7 @@ public class PluginLoader {
             try {
                 Class<?> definedClass = classLoader.loadClass(className);
 
-                if (definedClass != null && trustedPlugin(definedClass)) {
+                if (definedClass != null && isLoadablePlugin(definedClass)) {
                     return (Class<Plugin>) definedClass;
                 }
             } catch (ClassNotFoundException | NoClassDefFoundError e) {
@@ -163,5 +168,23 @@ public class PluginLoader {
         }
         classFileName = classFileName.replace("\\\\", "/").replace('/', '.');
         return classFileName.replace(File.separatorChar, '.');
+    }
+
+    public static final class LoadResult {
+        private final URLClassLoader classLoader;
+        private final Map<File, Class<Plugin>> pluginClasses;
+
+        private LoadResult(URLClassLoader classLoader, Map<File, Class<Plugin>> pluginClasses) {
+            this.classLoader = Objects.requireNonNull(classLoader);
+            this.pluginClasses = Collections.unmodifiableMap(new LinkedHashMap<>(pluginClasses));
+        }
+
+        public URLClassLoader getClassLoader() {
+            return classLoader;
+        }
+
+        public Map<File, Class<Plugin>> getPluginClasses() {
+            return pluginClasses;
+        }
     }
 }

--- a/application/src/main/java/net/emustudio/application/virtualcomputer/VirtualComputer.java
+++ b/application/src/main/java/net/emustudio/application/virtualcomputer/VirtualComputer.java
@@ -45,12 +45,19 @@ public class VirtualComputer implements PluginConnections, AutoCloseable {
 
 
     private final ComputerConfig computerConfig;
+    private final AutoCloseable pluginClassLoader;
 
     private final Map<Long, PluginMeta> pluginsById = new HashMap<>();
     private final Map<PLUGIN_TYPE, List<PluginMeta>> pluginsByType = new HashMap<>();
+    private boolean destroyed;
 
     public VirtualComputer(ComputerConfig computerConfig, Map<Long, PluginMeta> plugins) {
+        this(computerConfig, plugins, null);
+    }
+
+    public VirtualComputer(ComputerConfig computerConfig, Map<Long, PluginMeta> plugins, AutoCloseable pluginClassLoader) {
         this.computerConfig = Objects.requireNonNull(computerConfig);
+        this.pluginClassLoader = pluginClassLoader;
         plugins.forEach((pluginId, pluginMeta) -> {
             pluginsById.put(pluginId, pluginMeta);
 
@@ -65,11 +72,11 @@ public class VirtualComputer implements PluginConnections, AutoCloseable {
 
     public static VirtualComputer create(ComputerConfig computerConfig, ApplicationApi applicationApi,
                                          AppSettings appSettings) throws IOException, InvalidPluginException {
-        Map<Long, PluginMeta> plugins = loadPlugins(computerConfig, applicationApi, appSettings);
-        return new VirtualComputer(computerConfig, plugins);
+        LoadedPlugins loadedPlugins = loadPlugins(computerConfig, applicationApi, appSettings);
+        return new VirtualComputer(computerConfig, loadedPlugins.plugins, loadedPlugins.pluginClassLoader);
     }
 
-    private static Map<Long, PluginMeta> loadPlugins(
+    private static LoadedPlugins loadPlugins(
             ComputerConfig computerConfig,
             ApplicationApi applicationApi,
             AppSettings appSettings
@@ -90,26 +97,34 @@ public class VirtualComputer implements PluginConnections, AutoCloseable {
         LOGGER.debug("Loading plugin files: {}", filesToLoad);
 
         PluginLoader pluginLoader = new PluginLoader();
-        List<Class<Plugin>> pluginClasses = pluginLoader.loadPlugins(filesToLoad);
+        PluginLoader.LoadResult loadResult = pluginLoader.loadPlugins(filesToLoad);
 
-        return constructPlugins(pluginClasses, pluginConfigs, applicationApi, appSettings, computerConfig.getConfig()::save);
+        Map<Long, PluginMeta> plugins = constructPlugins(
+                loadResult.getPluginClasses(), pluginConfigs, applicationApi, appSettings, computerConfig.getConfig()::save
+        );
+        return new LoadedPlugins(loadResult.getClassLoader(), plugins);
     }
 
     // package-private for testing
     static Map<Long, PluginMeta> constructPlugins(
-            List<Class<Plugin>> pluginClasses,
+            Map<File, Class<Plugin>> pluginClassesByFile,
             List<PluginConfig> pluginConfigs,
             ApplicationApi applicationApi,
             AppSettings appSettings,
             Runnable save
     ) throws InvalidPluginException {
+        if (pluginClassesByFile.size() != pluginConfigs.size()) {
+            throw new InvalidPluginException("Plugin class count does not match plugin configuration count");
+        }
 
-        Map<Long, PluginMeta> plugins = new HashMap<>();
+        Map<Long, PluginMeta> plugins = new LinkedHashMap<>();
         AtomicLong pluginIdCounter = new AtomicLong(1); // 0 is reserved for emuStudio
 
-        for (int i = 0; i < Math.min(pluginClasses.size(), pluginConfigs.size()); i++) {
-            Class<Plugin> pluginClass = pluginClasses.get(i);
-            PluginConfig pluginConfig = pluginConfigs.get(i);
+        for (PluginConfig pluginConfig : pluginConfigs) {
+            Class<Plugin> pluginClass = pluginClassesByFile.get(pluginConfig.getPluginPath().toFile());
+            if (pluginClass == null) {
+                throw new InvalidPluginException("Missing loaded plugin class for " + pluginConfig.getPluginPath());
+            }
             PluginSettings pluginSettings = new PluginSettingsImpl(
                     pluginConfig.getPluginSettings(), appSettings, save
             );
@@ -206,7 +221,47 @@ public class VirtualComputer implements PluginConnections, AutoCloseable {
 
     @Override
     public void close() {
+        if (destroyed) {
+            return;
+        }
+        destroyed = true;
+        List<PluginMeta> devices = new ArrayList<>(pluginsByType.getOrDefault(PLUGIN_TYPE.DEVICE, Collections.emptyList()));
+        Collections.reverse(devices);
+        devices.forEach(meta -> safeDestroy(meta.pluginInstance));
+        getCPU().ifPresent(this::safeDestroy);
+        getMemory().ifPresent(this::safeDestroy);
+        getCompiler().ifPresent(this::safeDestroy);
+        safeCloseClassLoader();
         computerConfig.close();
+    }
+
+    private void safeDestroy(Plugin plugin) {
+        try {
+            plugin.destroy();
+        } catch (Exception e) {
+            LOGGER.error("Plugin {} failed to destroy", plugin, e);
+        }
+    }
+
+    private void safeCloseClassLoader() {
+        if (pluginClassLoader == null) {
+            return;
+        }
+        try {
+            pluginClassLoader.close();
+        } catch (Exception e) {
+            LOGGER.error("Plugin class loader failed to close", e);
+        }
+    }
+
+    private static final class LoadedPlugins {
+        private final AutoCloseable pluginClassLoader;
+        private final Map<Long, PluginMeta> plugins;
+
+        private LoadedPlugins(AutoCloseable pluginClassLoader, Map<Long, PluginMeta> plugins) {
+            this.pluginClassLoader = pluginClassLoader;
+            this.plugins = plugins;
+        }
     }
 
     static class PluginMeta {

--- a/application/src/test/java/net/emustudio/application/ApplicationApiImplTest.java
+++ b/application/src/test/java/net/emustudio/application/ApplicationApiImplTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 public class ApplicationApiImplTest {
@@ -30,5 +31,17 @@ public class ApplicationApiImplTest {
 
         api.setProgramLocation(1234);
         assertEquals(1234, api.getProgramLocation());
+    }
+
+    @Test
+    public void guiMayBeNullInHeadlessMode() {
+        ApplicationApiImpl api = new ApplicationApiImpl(
+                mock(DebuggerTable.class),
+                mock(ContextPool.class),
+                mock(Dialogs.class),
+                null
+        );
+
+        assertNull(api.getGUI());
     }
 }

--- a/application/src/test/java/net/emustudio/application/cmdline/AutomationCommandTest.java
+++ b/application/src/test/java/net/emustudio/application/cmdline/AutomationCommandTest.java
@@ -18,13 +18,11 @@ public class AutomationCommandTest {
 
     @Before
     public void setUp() {
-        cmdline = new CommandLine(new Runner());
-        cmdline.registerConverter(Path.class, Path::of);
-        cmdline.getCommandSpec().parser().collectErrors(true);
+        cmdline = Runner.createCommandLine(new Runner());
     }
 
     private AutomationCommand parseAutomationCommand(String... args) {
-        CommandLine.ParseResult result = cmdline.parseArgs(args);
+        CommandLine.ParseResult result = cmdline.parseArgs(Runner.normalizeArgs(args));
         assertTrue("Expected automation subcommand", result.hasSubcommand());
         return (AutomationCommand) result.subcommand().commandSpec().userObject();
     }
@@ -115,7 +113,7 @@ public class AutomationCommandTest {
 
     @Test
     public void autoAliasIsRecognized() {
-        CommandLine.ParseResult result = cmdline.parseArgs("auto");
+        CommandLine.ParseResult result = cmdline.parseArgs(Runner.normalizeArgs("auto"));
         assertTrue("Expected 'auto' to be recognized as automation subcommand", result.hasSubcommand());
         Object subcommand = result.subcommand().commandSpec().userObject();
         assertNotNull(subcommand);
@@ -124,7 +122,7 @@ public class AutomationCommandTest {
 
     @Test
     public void automationCommandNameIsRecognized() {
-        CommandLine.ParseResult result = cmdline.parseArgs("automation");
+        CommandLine.ParseResult result = cmdline.parseArgs(Runner.normalizeArgs("automation"));
         assertTrue(result.hasSubcommand());
         assertTrue(result.subcommand().commandSpec().userObject() instanceof AutomationCommand);
     }
@@ -148,7 +146,7 @@ public class AutomationCommandTest {
 
     @Test
     public void parsesInputFileFromParentCommand() throws Exception {
-        CommandLine.ParseResult result = cmdline.parseArgs("-i", "test.asm", "automation", "--no-gui");
+        CommandLine.ParseResult result = cmdline.parseArgs(Runner.normalizeArgs("-i", "test.asm", "automation", "--no-gui"));
         assertTrue(result.hasSubcommand());
 
         Runner runner = (Runner) result.commandSpec().userObject();
@@ -161,7 +159,7 @@ public class AutomationCommandTest {
 
     @Test
     public void parsesComputerNameWithAutomation() throws Exception {
-        CommandLine.ParseResult result = cmdline.parseArgs("-cn", "myComputer", "automation", "-w", "5000");
+        CommandLine.ParseResult result = cmdline.parseArgs(Runner.normalizeArgs("-cn", "myComputer", "automation", "-w", "5000"));
         assertTrue(result.hasSubcommand());
 
         Runner runner = (Runner) result.commandSpec().userObject();
@@ -173,8 +171,16 @@ public class AutomationCommandTest {
     }
 
     @Test
+    public void normalizesComputerNameAfterAutomationSubcommand() {
+        assertArrayEquals(
+                new String[]{"-cn", "myComputer", "automation", "--no-gui"},
+                Runner.normalizeArgs("automation", "--no-gui", "-cn", "myComputer")
+        );
+    }
+
+    @Test
     public void parsesComputerFileWithAutoAlias() throws Exception {
-        CommandLine.ParseResult result = cmdline.parseArgs("-cf", "/path/to/config.toml", "auto");
+        CommandLine.ParseResult result = cmdline.parseArgs(Runner.normalizeArgs("-cf", "/path/to/config.toml", "auto"));
         assertTrue(result.hasSubcommand());
 
         Runner runner = (Runner) result.commandSpec().userObject();

--- a/application/src/test/java/net/emustudio/application/cmdline/RunnerTest.java
+++ b/application/src/test/java/net/emustudio/application/cmdline/RunnerTest.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.util.Optional;
 
 import static org.junit.Assert.*;
+import picocli.CommandLine;
 
 public class RunnerTest {
     @Rule
@@ -41,11 +42,21 @@ public class RunnerTest {
     }
 
     @Test
-    public void mainTracksWhetherSubcommandWasUsed() throws Exception {
-        Runner.main(new String[]{"--help"});
-        assertFalse(Runner.runsSomeCommand);
+    public void executeArgsReturnsSuccessForHelp() {
+        assertEquals(0, Runner.executeArgs("--help"));
+        assertEquals(0, Runner.executeArgs("automation", "--help"));
+    }
 
-        Runner.main(new String[]{"automation", "--help"});
-        assertTrue(Runner.runsSomeCommand);
+    @Test
+    public void commandLineParsesInheritedOptionsBeforeAndAfterSubcommand() {
+        CommandLine cmdline = Runner.createCommandLine(new Runner());
+
+        CommandLine.ParseResult before = cmdline.parseArgs(Runner.normalizeArgs("-cn", "BrainDuck", "automation", "--no-gui"));
+        assertTrue(before.hasSubcommand());
+        assertEquals("BrainDuck", ((Runner) before.commandSpec().userObject()).exclusive.configName);
+
+        CommandLine.ParseResult after = cmdline.parseArgs(Runner.normalizeArgs("automation", "--no-gui", "-cn", "BrainDuck"));
+        assertTrue(after.hasSubcommand());
+        assertEquals("BrainDuck", ((Runner) after.commandSpec().userObject()).exclusive.configName);
     }
 }

--- a/application/src/test/java/net/emustudio/application/emulation/AutomationBoundaryTest.java
+++ b/application/src/test/java/net/emustudio/application/emulation/AutomationBoundaryTest.java
@@ -1,0 +1,45 @@
+/* SPDX-FileCopyrightText: 2006-2026 Peter Jakubčo
+   SPDX-License-Identifier: GPL-3.0-or-later */
+package net.emustudio.application.emulation;
+
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+
+public class AutomationBoundaryTest {
+
+    @Test
+    public void automationApiDoesNotExposeGuiPackageTypes() {
+        assertFalse(usesGuiType(Automation.class.getDeclaredFields()));
+        assertFalse(usesGuiType(Automation.class.getDeclaredConstructors()));
+        assertFalse(usesGuiType(Automation.class.getDeclaredMethods()));
+    }
+
+    private static boolean usesGuiType(Field[] fields) {
+        return Arrays.stream(fields)
+                .map(Field::getType)
+                .anyMatch(AutomationBoundaryTest::isGuiType);
+    }
+
+    private static boolean usesGuiType(Constructor<?>[] constructors) {
+        return Arrays.stream(constructors)
+                .flatMap(constructor -> Arrays.stream(constructor.getParameterTypes()))
+                .anyMatch(AutomationBoundaryTest::isGuiType);
+    }
+
+    private static boolean usesGuiType(Method[] methods) {
+        return Arrays.stream(methods)
+                .flatMap(method -> Arrays.stream(method.getParameterTypes()))
+                .anyMatch(AutomationBoundaryTest::isGuiType);
+    }
+
+    private static boolean isGuiType(Class<?> type) {
+        Package typePackage = type.getPackage();
+        return typePackage != null && typePackage.getName().startsWith("net.emustudio.application.gui");
+    }
+}

--- a/application/src/test/java/net/emustudio/application/emulation/AutomationTest.java
+++ b/application/src/test/java/net/emustudio/application/emulation/AutomationTest.java
@@ -3,7 +3,6 @@
 package net.emustudio.application.emulation;
 
 import com.electronwill.nightconfig.core.Config;
-import net.emustudio.application.gui.dialogs.AutoDialog;
 import net.emustudio.application.settings.AppSettings;
 import net.emustudio.application.settings.ComputerConfig;
 import net.emustudio.application.virtualcomputer.VirtualComputer;
@@ -51,7 +50,7 @@ public class AutomationTest {
     public void constructorRejectsMissingInputFile() throws Exception {
         new Automation(
                 mockComputer(), Path.of("missing-" + System.nanoTime() + ".asm"),
-                NO_GUI_SETTINGS, dialogs, 10, null, null
+                NO_GUI_SETTINGS, dialogs, 10, null, EmulationProgress.NONE
         );
     }
 
@@ -59,7 +58,7 @@ public class AutomationTest {
     public void runReportsCompilationFailureAndSkipsCpuExecution() throws Exception {
         stubCompilation(CompilerMessage.MessageType.TYPE_ERROR, "Broken source");
 
-        new Automation(mockComputer(compiler, cpu), input, NO_GUI_SETTINGS, dialogs, 50, null, null).run();
+        new Automation(mockComputer(compiler, cpu), input, NO_GUI_SETTINGS, dialogs, 50, null, EmulationProgress.NONE).run();
 
         verify(cpu, never()).reset();
         verify(cpu, never()).execute();
@@ -75,7 +74,7 @@ public class AutomationTest {
 
         new Automation(
                 mockComputer(compiler, cpu, mock(Memory.class), Collections.singletonList(device)),
-                input, NO_GUI_SETTINGS, dialogs, 200, 0x20, null
+                input, NO_GUI_SETTINGS, dialogs, 200, 0x20, EmulationProgress.NONE
         ).run();
 
         verify(cpu).reset(0x20);
@@ -90,7 +89,7 @@ public class AutomationTest {
         stubCpuExecution(CPU.RunState.STATE_STOPPED_BREAK);
         when(cpu.getInstructionLocation()).thenReturn(0x0088);
 
-        new Automation(mockComputer(compiler, cpu), input, NO_GUI_SETTINGS, dialogs, 200, null, null).run();
+        new Automation(mockComputer(compiler, cpu), input, NO_GUI_SETTINGS, dialogs, 200, null, EmulationProgress.NONE).run();
 
         verify(cpu).reset();
         verify(cpu, never()).reset(anyInt());
@@ -104,7 +103,7 @@ public class AutomationTest {
         when(cpu.getInstructionLocation()).thenReturn(0x0042);
         Compiler unusedCompiler = mock(Compiler.class);
 
-        new Automation(mockComputer(unusedCompiler, cpu), null, NO_GUI_SETTINGS, dialogs, 20, null, null).run();
+        new Automation(mockComputer(unusedCompiler, cpu), null, NO_GUI_SETTINGS, dialogs, 20, null, EmulationProgress.NONE).run();
 
         verify(cpu).reset();
         verify(cpu).execute();
@@ -120,7 +119,7 @@ public class AutomationTest {
         doAnswer(inv -> { started.countDown(); return null; }).when(cpu).execute();
         when(cpu.getInstructionLocation()).thenReturn(0);
 
-        Automation automation = new Automation(mockComputer(cpu), null, NO_GUI_SETTINGS, dialogs, Automation.DONT_WAIT, null, null);
+        Automation automation = new Automation(mockComputer(cpu), null, NO_GUI_SETTINGS, dialogs, Automation.DONT_WAIT, null, EmulationProgress.NONE);
 
         Thread thread = new Thread(() -> {
             automation.run();
@@ -137,18 +136,29 @@ public class AutomationTest {
     @Test
     public void runUsesProgressDialogWhenPresent() throws Exception {
         when(cpu.getInstructionLocation()).thenReturn(0x0010);
-        AutoDialog progressDialog = mock(AutoDialog.class);
+        EmulationProgress progress = mock(EmulationProgress.class);
 
-        Automation automation = new Automation(mockComputer(cpu), null, NO_GUI_SETTINGS, dialogs, 10, null, null);
-        automation.progressGUI = progressDialog;
+        Automation automation = new Automation(mockComputer(cpu), null, NO_GUI_SETTINGS, dialogs, 10, null, progress);
 
         automation.run();
 
-        verify(progressDialog).setVisible(true);
-        verify(progressDialog).setAction("Resetting CPU...", false);
-        verify(progressDialog).setAction("Running emulation...", true);
-        verify(progressDialog).setAction("Emulation completed", false);
-        verify(progressDialog).dispose();
+        verify(progress).show();
+        verify(progress).setAction("Resetting CPU...", false);
+        verify(progress).setAction("Running emulation...", true);
+        verify(progress).setAction("Emulation completed", false);
+        verify(progress).dispose();
+    }
+
+    @Test
+    public void runReturnsWhenCpuStopsBeforeWaitBegins() throws Exception {
+        stubCompilation(CompilerMessage.MessageType.TYPE_INFO, "Compiled");
+        stubCpuExecutionImmediately(CPU.RunState.STATE_STOPPED_NORMAL);
+        when(cpu.getInstructionLocation()).thenReturn(0x0042);
+
+        new Automation(mockComputer(compiler, cpu), input, NO_GUI_SETTINGS, dialogs, Automation.DONT_WAIT, null, EmulationProgress.NONE).run();
+
+        verify(cpu).execute();
+        verify(dialogs, never()).showError(anyString(), anyString());
     }
 
     private void stubCompilation(CompilerMessage.MessageType messageType, String message) throws Exception {
@@ -168,10 +178,17 @@ public class AutomationTest {
         doAnswer(inv -> { listener.set(inv.getArgument(0)); return null; })
                 .when(cpu).addCPUListener(any());
         doAnswer(inv -> {
-            new Thread(() -> {
-                try { Thread.sleep(25); } catch (InterruptedException ignored) { Thread.currentThread().interrupt(); }
-                listener.get().runStateChanged(stopState);
-            }).start();
+            listener.get().runStateChanged(stopState);
+            return null;
+        }).when(cpu).execute();
+    }
+
+    private void stubCpuExecutionImmediately(CPU.RunState stopState) {
+        AtomicReference<CPU.CPUListener> listener = new AtomicReference<>();
+        doAnswer(inv -> { listener.set(inv.getArgument(0)); return null; })
+                .when(cpu).addCPUListener(any());
+        doAnswer(inv -> {
+            listener.get().runStateChanged(stopState);
             return null;
         }).when(cpu).execute();
     }

--- a/application/src/test/java/net/emustudio/application/virtualcomputer/PluginLoaderTest.java
+++ b/application/src/test/java/net/emustudio/application/virtualcomputer/PluginLoaderTest.java
@@ -46,7 +46,7 @@ public class PluginLoaderTest {
     }
 
     private Collection<Class<Plugin>> loadBadPlugin(PluginLoader instance) throws Exception {
-        return instance.loadPlugins(Collections.singletonList(toFile(BAD_PLUGIN_PATH)));
+        return instance.loadPlugins(Collections.singletonList(toFile(BAD_PLUGIN_PATH))).getPluginClasses().values();
     }
 
     @SuppressWarnings("unchecked")
@@ -67,23 +67,23 @@ public class PluginLoaderTest {
     }
 
     @Test
-    public void testCorrectTrustedPlugin() throws Exception {
-        assertTrue(PluginLoader.trustedPlugin(loadValidPlugin()));
+    public void testCorrectLoadablePlugin() throws Exception {
+        assertTrue(PluginLoader.isLoadablePlugin(loadValidPlugin()));
     }
 
     @Test
-    public void testTrustedPluginOnNotAPluginClassReturnsFalse() {
-        assertFalse(PluginLoader.trustedPlugin(CPU.CPUListener.class));
+    public void testLoadablePluginOnNotAPluginClassReturnsFalse() {
+        assertFalse(PluginLoader.isLoadablePlugin(CPU.CPUListener.class));
     }
 
     @Test
-    public void testTrustedPluginOnInterfaceReturnsFalse() {
-        assertFalse(PluginLoader.trustedPlugin(CPU.class));
+    public void testLoadablePluginOnInterfaceReturnsFalse() {
+        assertFalse(PluginLoader.isLoadablePlugin(CPU.class));
     }
 
     @Test
-    public void testTrustedPluginOnPluginClassWithoutAnnotation() {
-        assertFalse(PluginLoader.trustedPlugin(AbstractCPU.class));
+    public void testLoadablePluginOnPluginClassWithoutAnnotation() {
+        assertFalse(PluginLoader.isLoadablePlugin(AbstractCPU.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -121,7 +121,7 @@ public class PluginLoaderTest {
 
         // Since PluginLoader must share ClassLoader with current one, emuLib is preloaded automatically
         pluginLoader = new PluginLoader();
-        Class<Plugin> cl = pluginLoader.loadPlugins(List.of(plugin)).iterator().next();
+        Class<Plugin> cl = pluginLoader.loadPlugins(List.of(plugin)).getPluginClasses().values().iterator().next();
 
         Constructor<Plugin> constructor = cl.getDeclaredConstructor(long.class, ApplicationApi.class, PluginSettings.class);
         cl.getDeclaredMethod("hi").invoke(constructor.newInstance(

--- a/application/src/test/java/net/emustudio/application/virtualcomputer/VirtualComputerTest.java
+++ b/application/src/test/java/net/emustudio/application/virtualcomputer/VirtualComputerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import javax.swing.*;
+import java.io.File;
 import java.util.*;
 
 import static org.junit.Assert.*;
@@ -159,7 +160,8 @@ public class VirtualComputerTest {
         ApplicationApi applicationApi = mock(ApplicationApi.class);
 
         Map<Long, PluginMeta> result = VirtualComputer.constructPlugins(
-                List.of((Class<Plugin>) (Class<?>) TestCompilerPlugin.class),
+                pluginClassesByFile(List.of(pluginConfig("compiler", PLUGIN_TYPE.COMPILER)),
+                        List.of((Class<Plugin>) (Class<?>) TestCompilerPlugin.class)),
                 List.of(pluginConfig("compiler", PLUGIN_TYPE.COMPILER)),
                 applicationApi,
                 new AppSettings(Config.inMemory(), true, false),
@@ -177,8 +179,48 @@ public class VirtualComputerTest {
     @SuppressWarnings("unchecked")
     public void constructPluginsRejectsPluginThatDoesNotImplementExpectedInterface() {
         assertThrows(InvalidPluginException.class, () -> VirtualComputer.constructPlugins(
-                List.of((Class<Plugin>) (Class<?>) NotACompilerPlugin.class),
+                pluginClassesByFile(List.of(pluginConfig("compiler", PLUGIN_TYPE.COMPILER)),
+                        List.of((Class<Plugin>) (Class<?>) NotACompilerPlugin.class)),
                 List.of(pluginConfig("compiler", PLUGIN_TYPE.COMPILER)),
+                mock(ApplicationApi.class),
+                new AppSettings(Config.inMemory(), true, false),
+                () -> {}
+        ));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void constructPluginsPairsClassesByConfiguredPluginPath() throws Exception {
+        PluginConfig compilerConfig = pluginConfig("compiler", PLUGIN_TYPE.COMPILER);
+        PluginConfig memoryConfig = pluginConfig("memory", PLUGIN_TYPE.MEMORY);
+
+        Map<File, Class<Plugin>> pluginClasses = new LinkedHashMap<>();
+        pluginClasses.put(memoryConfig.getPluginPath().toFile(), (Class<Plugin>) (Class<?>) TestMemoryPlugin.class);
+        pluginClasses.put(compilerConfig.getPluginPath().toFile(), (Class<Plugin>) (Class<?>) TestCompilerPlugin.class);
+
+        Map<Long, PluginMeta> result = VirtualComputer.constructPlugins(
+                pluginClasses,
+                List.of(compilerConfig, memoryConfig),
+                mock(ApplicationApi.class),
+                new AppSettings(Config.inMemory(), true, false),
+                () -> {}
+        );
+
+        assertTrue(result.get(1L).pluginInstance instanceof TestCompilerPlugin);
+        assertTrue(result.get(2L).pluginInstance instanceof TestMemoryPlugin);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void constructPluginsRejectsMismatchedPluginCounts() {
+        PluginConfig compilerConfig = pluginConfig("compiler", PLUGIN_TYPE.COMPILER);
+        Map<File, Class<Plugin>> pluginClasses = new LinkedHashMap<>();
+        pluginClasses.put(compilerConfig.getPluginPath().toFile(), (Class<Plugin>) (Class<?>) TestCompilerPlugin.class);
+        pluginClasses.put(new File("/tmp/extra.jar"), (Class<Plugin>) (Class<?>) TestCompilerPlugin.class);
+
+        assertThrows(InvalidPluginException.class, () -> VirtualComputer.constructPlugins(
+                pluginClasses,
+                List.of(compilerConfig),
                 mock(ApplicationApi.class),
                 new AppSettings(Config.inMemory(), true, false),
                 () -> {}
@@ -199,8 +241,78 @@ public class VirtualComputerTest {
         );
     }
 
+    @Test
+    public void closeDestroysPluginsInReverseOrderAndClosesClassLoader() throws Exception {
+        Compiler compiler = mock(Compiler.class);
+        Memory memory = mock(Memory.class);
+        CPU cpu = mock(CPU.class);
+        Device d1 = mock(Device.class);
+        Device d2 = mock(Device.class);
+        AutoCloseable classLoader = mock(AutoCloseable.class);
+        ComputerConfig computerConfig = mock(ComputerConfig.class);
+
+        VirtualComputer vc = new VirtualComputer(computerConfig, plugins(
+                plugin(0L, pluginConfig("compiler", PLUGIN_TYPE.COMPILER), compiler),
+                plugin(1L, pluginConfig("memory", PLUGIN_TYPE.MEMORY), memory),
+                plugin(2L, pluginConfig("cpu", PLUGIN_TYPE.CPU), cpu),
+                plugin(3L, pluginConfig("device-1", PLUGIN_TYPE.DEVICE), d1),
+                plugin(4L, pluginConfig("device-2", PLUGIN_TYPE.DEVICE), d2)
+        ), classLoader);
+
+        vc.close();
+
+        InOrder inOrder = inOrder(d2, d1, cpu, memory, compiler, classLoader, computerConfig);
+        inOrder.verify(d2).destroy();
+        inOrder.verify(d1).destroy();
+        inOrder.verify(cpu).destroy();
+        inOrder.verify(memory).destroy();
+        inOrder.verify(compiler).destroy();
+        inOrder.verify(classLoader).close();
+        inOrder.verify(computerConfig).close();
+    }
+
+    @Test
+    public void closeContinuesAfterDestroyFailureAndIsIdempotent() throws Exception {
+        Compiler compiler = mock(Compiler.class);
+        Memory memory = mock(Memory.class);
+        CPU cpu = mock(CPU.class);
+        Device badDevice = mock(Device.class);
+        Device goodDevice = mock(Device.class);
+        AutoCloseable classLoader = mock(AutoCloseable.class);
+        ComputerConfig computerConfig = mock(ComputerConfig.class);
+        doThrow(new RuntimeException("boom")).when(badDevice).destroy();
+
+        VirtualComputer vc = new VirtualComputer(computerConfig, plugins(
+                plugin(0L, pluginConfig("compiler", PLUGIN_TYPE.COMPILER), compiler),
+                plugin(1L, pluginConfig("memory", PLUGIN_TYPE.MEMORY), memory),
+                plugin(2L, pluginConfig("cpu", PLUGIN_TYPE.CPU), cpu),
+                plugin(3L, pluginConfig("bad-device", PLUGIN_TYPE.DEVICE), badDevice),
+                plugin(4L, pluginConfig("good-device", PLUGIN_TYPE.DEVICE), goodDevice)
+        ), classLoader);
+
+        vc.close();
+        vc.close();
+
+        verify(goodDevice).destroy();
+        verify(badDevice).destroy();
+        verify(cpu).destroy();
+        verify(memory).destroy();
+        verify(compiler).destroy();
+        verify(classLoader).close();
+        verify(computerConfig).close();
+        verifyNoMoreInteractions(classLoader, computerConfig);
+    }
+
     private static PluginConfig pluginConfig(String id, PLUGIN_TYPE pluginType) {
         return PluginConfig.create(id, pluginType, id, "/tmp/" + id + ".jar", P.of(0, 0), Config.inMemory());
+    }
+
+    private static Map<File, Class<Plugin>> pluginClassesByFile(List<PluginConfig> pluginConfigs, List<Class<Plugin>> pluginClasses) {
+        Map<File, Class<Plugin>> result = new LinkedHashMap<>();
+        for (int i = 0; i < pluginConfigs.size() && i < pluginClasses.size(); i++) {
+            result.put(pluginConfigs.get(i).getPluginPath().toFile(), pluginClasses.get(i));
+        }
+        return result;
     }
 
     private static Map<Long, PluginMeta> plugins(PluginEntry... entries) {
@@ -270,6 +382,22 @@ public class VirtualComputerTest {
         @Override public String getVersion() { return "test"; }
         @Override public String getCopyright() { return "test"; }
         @Override public String getDescription() { return "test"; }
+    }
+
+    public static final class TestMemoryPlugin implements Memory {
+        public TestMemoryPlugin(long pluginId, ApplicationApi applicationApi, PluginSettings settings) {}
+
+        @Override public void reset() {}
+        @Override public void initialize() {}
+        @Override public void destroy() {}
+        @Override public void showSettings(JFrame parent) {}
+        @Override public boolean isShowSettingsSupported() { return false; }
+        @Override public net.emustudio.emulib.plugins.memory.annotations.MemoryAnnotations getAnnotations() { return null; }
+        @Override public int getSize() { return 0; }
+        @Override public String getTitle() { return "memory"; }
+        @Override public String getVersion() { return "memory"; }
+        @Override public String getCopyright() { return "memory"; }
+        @Override public String getDescription() { return "memory"; }
     }
 
     public static final class BrokenCompilerPlugin implements Compiler {

--- a/docs/adr/0001-record-architecture-decisions.adoc
+++ b/docs/adr/0001-record-architecture-decisions.adoc
@@ -1,0 +1,13 @@
+# ADR-0001: Record Architecture Decisions
+
+## Status
+Accepted
+
+## Context
+The project already carries durable architecture choices, but they were not recorded in `docs/adr` as required by `AGENTS.md`.
+
+## Decision
+Store short Architecture Decision Records in `docs/adr` using sequential `ADR-NNNN` files and the compact template required by the repository instructions.
+
+## Consequences
+Important design choices get a stable home. Future changes must update or supersede ADRs instead of relying on tribal knowledge.

--- a/docs/adr/0002-plugin-loading-contract.adoc
+++ b/docs/adr/0002-plugin-loading-contract.adoc
@@ -1,0 +1,13 @@
+# ADR-0002: Plugin Loading Contract
+
+## Status
+Accepted
+
+## Context
+emuStudio loads plugin JARs dynamically and must identify one valid root per configured plugin while keeping plugin dependencies isolated from application classes.
+
+## Decision
+Load each virtual computer through a dedicated `URLClassLoader`. Treat a class as loadable only when it is annotated with `@PluginRoot` and implements `Plugin`, then match loaded classes back to configured plugin JAR paths before instantiation.
+
+## Consequences
+Plugin discovery stays explicit and stable. Shutdown must close the per-computer class loader, and configuration mismatches now fail fast instead of being paired positionally.

--- a/docs/adr/0003-context-interface-hashing.adoc
+++ b/docs/adr/0003-context-interface-hashing.adoc
@@ -1,0 +1,13 @@
+# ADR-0003: Context Interface Hashing
+
+## Status
+Accepted
+
+## Context
+Plugins from different class loaders need a stable way to decide whether two context interfaces describe the same contract.
+
+## Decision
+Compute a SHA-1 hash from each context interface method signature and use that hash as the compatibility key inside `ContextPoolImpl`.
+
+## Consequences
+Context matching stays class-loader independent and deterministic. Signature changes are breaking changes and must be coordinated across plugins.

--- a/docs/adr/0004-virtual-computer-project-format.adoc
+++ b/docs/adr/0004-virtual-computer-project-format.adoc
@@ -1,0 +1,13 @@
+# ADR-0004: Virtual Computer Project Format
+
+## Status
+Accepted
+
+## Context
+emuStudio composes a virtual computer from plugins, layout metadata, and explicit wiring rules that must be persisted in a portable project format.
+
+## Decision
+Represent virtual computers with TOML configuration files that declare compiler, CPU, memory, devices, plugin settings, and explicit connections between plugins.
+
+## Consequences
+Projects stay human-readable and source-control friendly. Loader, schema editor, and runtime wiring must remain compatible with the TOML model or ship migrations.

--- a/docs/adr/0005-headless-automation-mode.adoc
+++ b/docs/adr/0005-headless-automation-mode.adoc
@@ -1,0 +1,13 @@
+# ADR-0005: Headless Automation Mode
+
+## Status
+Accepted
+
+## Context
+Automation must run without Swing while preserving the same plugin API used by interactive runs.
+
+## Decision
+Treat headless automation as a first-class mode. `ApplicationApi.getGUI()` may be `null`, and automation uses a no-op progress implementation instead of synthesizing GUI services.
+
+## Consequences
+Plugins can detect headless mode through the existing API contract. Runtime code must not assume GUI availability, and automation tests must cover `--no-gui`.

--- a/docs/adr/0006-plugin-lifecycle-and-classloader-ownership.adoc
+++ b/docs/adr/0006-plugin-lifecycle-and-classloader-ownership.adoc
@@ -1,0 +1,13 @@
+# ADR-0006: Plugin Lifecycle And ClassLoader Ownership
+
+## Status
+Accepted
+
+## Context
+Plugins may allocate threads, audio lines, and class-loader resources that outlive a run unless shutdown is explicit and ordered.
+
+## Decision
+`VirtualComputer.close()` is responsible for plugin shutdown. It destroys plugins in reverse initialization order, then closes the dedicated plugin class loader, then closes the configuration.
+
+## Consequences
+Shutdown becomes explicit and idempotent. Future reload or multi-computer flows can reuse the same lifecycle contract instead of relying on process exit.

--- a/docs/adr/0007-automation-progress-ui-boundary.adoc
+++ b/docs/adr/0007-automation-progress-ui-boundary.adoc
@@ -1,0 +1,13 @@
+# ADR-0007: Automation Progress UI Boundary
+
+## Status
+Accepted
+
+## Context
+Automation runtime logic needs progress reporting, but direct Swing dependencies in the emulation package break the intended runtime-to-UI boundary.
+
+## Decision
+Expose automation progress through an `EmulationProgress` port in the emulation package. GUI code implements that port with `AutoDialog`; headless mode uses a no-op implementation.
+
+## Consequences
+Runtime code no longer depends on Swing dialogs directly. New progress UIs can be added without changing emulation logic.

--- a/docs/code.adoc
+++ b/docs/code.adoc
@@ -66,8 +66,8 @@ package "emuStudio application" {
         +getCompiler()/getCPU()/getMemory()/getDevices()
     }
     class PluginLoader {
-        +loadPlugins(files) : List<Class<Plugin>>
-        -trustedPlugin(class) : boolean
+        +loadPlugins(files) : LoadResult
+        -isLoadablePlugin(class) : boolean
     }
     class ContextPoolImpl
     class ApplicationApiImpl
@@ -98,7 +98,7 @@ is a single constructor with the signature:
 public SamplePlugin(long pluginId, ApplicationApi emustudio, PluginSettings settings) { … }
 ----
 
-`PluginLoader.trustedPlugin(...)` accepts a class only if it is not an interface,
+`PluginLoader.isLoadablePlugin(...)` accepts a class only if it is not an interface,
 is annotated with `@PluginRoot`, and implements `Plugin`. `VirtualComputer` then
 additionally checks that the class implements the interface matching its declared
 `PLUGIN_TYPE` before instantiating it.
@@ -122,8 +122,8 @@ participant "ContextPoolImpl" as CP
 User -> Runner : select configuration
 Runner -> VC : create(config, applicationApi, appSettings)
 VC -> PL : loadPlugins(jarFiles)
-PL -> PL : findMainClass() + trustedPlugin()
-PL --> VC : List<Class<Plugin>>
+PL -> PL : findMainClass() + isLoadablePlugin()
+PL --> VC : LoadResult(classLoader, classesByFile)
 
 loop for each plugin (compiler, CPU, memory, devices)
     VC -> VC : check type implements PLUGIN_TYPE interface

--- a/docs/components.adoc
+++ b/docs/components.adoc
@@ -105,8 +105,9 @@ context.
 
 PluginLoader:: Loads plugin JARs into a dedicated `URLClassLoader` (including
 each JAR's declared `Class-Path` dependencies), scans the classes and returns
-the single *trusted* main class — the one that is annotated `@PluginRoot` and
-implements the `Plugin` contract.
+the single loadable main class for each configured JAR — the one that is
+annotated `@PluginRoot` and implements the `Plugin` contract. The
+`VirtualComputer` owns that class loader and closes it during shutdown.
 
 ContextPool:: The mediator through which plugins communicate. Plugins *register*
 the contexts they provide and *request* the contexts they need; the pool matches

--- a/gradle/conventions/java-conventions.gradle
+++ b/gradle/conventions/java-conventions.gradle
@@ -2,6 +2,12 @@
    SPDX-License-Identifier: GPL-3.0-or-later */
 import org.apache.tools.ant.filters.ReplaceTokens
 
+java {
+  toolchain {
+    languageVersion = JavaLanguageVersion.of(11)
+  }
+}
+
 jar {
   archiveVersion = ''
   manifest {

--- a/plugins/cpu/8080-cpu/src/main/java/net/emustudio/plugins/cpu/intel8080/gui/StatusPanel.java
+++ b/plugins/cpu/8080-cpu/src/main/java/net/emustudio/plugins/cpu/intel8080/gui/StatusPanel.java
@@ -71,7 +71,9 @@ public class StatusPanel extends JPanel {
                 updateGUI();
             }
         });
-        cpu.getFrequencyCalculator().addListener(f -> lblFrequency.setText(String.format("%.2f kHz", f)));
+        cpu.getFrequencyCalculator().addListener(
+                f -> SwingUtilities.invokeLater(() -> lblFrequency.setText(String.format("%.2f kHz", f)))
+        );
         spnFrequency.addChangeListener(e -> {
             int i = (Integer) spnFrequency.getModel().getValue();
             try {
@@ -83,22 +85,24 @@ public class StatusPanel extends JPanel {
     }
 
     public void updateGUI() {
-        txtRegA.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_A]));
-        txtRegB.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_B]));
-        txtRegC.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_C]));
-        txtRegBC.setText(formatWordHexString((short) engine.regs[EmulatorEngine.REG_B], (short) engine.regs[EmulatorEngine.REG_C]));
-        txtRegD.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_D]));
-        txtRegE.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_E]));
-        txtRegDE.setText(formatWordHexString((short) engine.regs[EmulatorEngine.REG_D], (short) engine.regs[EmulatorEngine.REG_E]));
-        txtRegH.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_H]));
-        txtRegL.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_L]));
-        txtRegHL.setText(formatWordHexString((short) engine.regs[EmulatorEngine.REG_H], (short) engine.regs[EmulatorEngine.REG_L]));
-        txtRegSP.setText(formatWordHexString(engine.SP));
-        txtRegPC.setText(formatWordHexString(engine.PC));
-        txtFlags.setText(formatByteHexString(engine.flags));
-        flagModel.fireTableDataChanged();
-        lblRun.setText(runState.toString());
-        spnFrequency.setEnabled(runState != RunState.STATE_RUNNING);
+        SwingUtilities.invokeLater(() -> {
+            txtRegA.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_A]));
+            txtRegB.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_B]));
+            txtRegC.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_C]));
+            txtRegBC.setText(formatWordHexString((short) engine.regs[EmulatorEngine.REG_B], (short) engine.regs[EmulatorEngine.REG_C]));
+            txtRegD.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_D]));
+            txtRegE.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_E]));
+            txtRegDE.setText(formatWordHexString((short) engine.regs[EmulatorEngine.REG_D], (short) engine.regs[EmulatorEngine.REG_E]));
+            txtRegH.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_H]));
+            txtRegL.setText(formatByteHexString(engine.regs[EmulatorEngine.REG_L]));
+            txtRegHL.setText(formatWordHexString((short) engine.regs[EmulatorEngine.REG_H], (short) engine.regs[EmulatorEngine.REG_L]));
+            txtRegSP.setText(formatWordHexString(engine.SP));
+            txtRegPC.setText(formatWordHexString(engine.PC));
+            txtFlags.setText(formatByteHexString(engine.flags));
+            flagModel.fireTableDataChanged();
+            lblRun.setText(runState.toString());
+            spnFrequency.setEnabled(runState != RunState.STATE_RUNNING);
+        });
     }
 
     private void initComponents() {

--- a/plugins/cpu/brainduck-cpu/src/main/java/net/emustudio/plugins/cpu/brainduck/gui/StatusPanel.java
+++ b/plugins/cpu/brainduck-cpu/src/main/java/net/emustudio/plugins/cpu/brainduck/gui/StatusPanel.java
@@ -88,50 +88,56 @@ public class StatusPanel extends JPanel {
 
         @Override
         public void runStateChanged(CPU.RunState state) {
-            switch (state) {
-                case STATE_RUNNING:
-                    lblRunState.setText("running");
-                    lblTime.setText("N/A");
-                    nanoStartTime = System.nanoTime();
-                    break;
-                case STATE_STOPPED_NORMAL:
-                    lblRunState.setText("stopped (normal)");
-                    break;
-                case STATE_STOPPED_BREAK:
-                    lblRunState.setText("breakpoint");
-                    break;
-                case STATE_STOPPED_ADDR_FALLOUT:
-                    lblRunState.setText("stopped (address fallout)");
-                    break;
-                case STATE_STOPPED_BAD_INSTR:
-                    lblRunState.setText("stopped (instruction fallout)");
-                    break;
-            }
             long tmpNanoTime = 0;
             if (state != CPU.RunState.STATE_RUNNING && nanoStartTime != 0) {
                 tmpNanoTime = System.nanoTime() - nanoStartTime;
                 nanoStartTime = 0;
             }
-            lblTime.setText(String.format("%.2f ms", (double) tmpNanoTime / 1000000.0));
+            final long elapsed = tmpNanoTime;
+            SwingUtilities.invokeLater(() -> {
+                switch (state) {
+                    case STATE_RUNNING:
+                        lblRunState.setText("running");
+                        lblTime.setText("N/A");
+                        break;
+                    case STATE_STOPPED_NORMAL:
+                        lblRunState.setText("stopped (normal)");
+                        break;
+                    case STATE_STOPPED_BREAK:
+                        lblRunState.setText("breakpoint");
+                        break;
+                    case STATE_STOPPED_ADDR_FALLOUT:
+                        lblRunState.setText("stopped (address fallout)");
+                        break;
+                    case STATE_STOPPED_BAD_INSTR:
+                        lblRunState.setText("stopped (instruction fallout)");
+                        break;
+                }
+                lblTime.setText(String.format("%.2f ms", (double) elapsed / 1000000.0));
+            });
+            if (state == CPU.RunState.STATE_RUNNING) {
+                nanoStartTime = System.nanoTime();
+            }
         }
 
         @Override
         public void internalStateChanged() {
             int P = cpu.getP();
-
-            txtP.setText(String.format("%04X", P));
-            txtIP.setText(String.format("%04X", cpu.IP));
-            lblLoopLevel.setText(String.valueOf(cpu.getLoopLevel()));
-            try {
-                txtMemP.setText(String.format("%02X", memory[P] & 0xFF));
-            } catch (ArrayIndexOutOfBoundsException e) {
-                txtMemP.setText("[unreachable]");
-            } finally {
-                tableModel.setP(P);
-                columnsRepainter.repaint(tblMemory);
-                tblMemory.revalidate();
-                tblMemory.repaint();
-            }
+            SwingUtilities.invokeLater(() -> {
+                txtP.setText(String.format("%04X", P));
+                txtIP.setText(String.format("%04X", cpu.IP));
+                lblLoopLevel.setText(String.valueOf(cpu.getLoopLevel()));
+                try {
+                    txtMemP.setText(String.format("%02X", memory[P] & 0xFF));
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    txtMemP.setText("[unreachable]");
+                } finally {
+                    tableModel.setP(P);
+                    columnsRepainter.repaint(tblMemory);
+                    tblMemory.revalidate();
+                    tblMemory.repaint();
+                }
+            });
         }
     }
 

--- a/plugins/cpu/ram-cpu/src/main/java/net/emustudio/plugins/cpu/ram/gui/RamStatusPanel.java
+++ b/plugins/cpu/ram-cpu/src/main/java/net/emustudio/plugins/cpu/ram/gui/RamStatusPanel.java
@@ -28,7 +28,7 @@ public class RamStatusPanel extends JPanel {
         cpu.addCPUListener(new CPU.CPUListener() {
             @Override
             public void runStateChanged(CPU.RunState state) {
-                lblStatus.setText(state.toString());
+                SwingUtilities.invokeLater(() -> lblStatus.setText(state.toString()));
             }
 
             @Override
@@ -37,11 +37,14 @@ public class RamStatusPanel extends JPanel {
                 if (r0.isEmpty()) {
                     r0 = "<empty>";
                 }
-                txtR0.setText(r0);
-                txtIP.setText(String.format("%04d", cpu.getInstructionLocation()));
-                txtInput.setText(input.getSymbolAt(input.getHeadPosition()).map(TapeSymbol::toString).orElse("<empty>"));
                 int outputPos = Math.max(0, output.getHeadPosition() - 1);
-                txtOutput.setText(output.getSymbolAt(outputPos).map(TapeSymbol::toString).orElse("<empty>"));
+                String finalR0 = r0;
+                SwingUtilities.invokeLater(() -> {
+                    txtR0.setText(finalR0);
+                    txtIP.setText(String.format("%04d", cpu.getInstructionLocation()));
+                    txtInput.setText(input.getSymbolAt(input.getHeadPosition()).map(TapeSymbol::toString).orElse("<empty>"));
+                    txtOutput.setText(output.getSymbolAt(outputPos).map(TapeSymbol::toString).orElse("<empty>"));
+                });
             }
         });
     }

--- a/plugins/cpu/rasp-cpu/src/main/java/net/emustudio/plugins/cpu/rasp/gui/RaspStatusPanel.java
+++ b/plugins/cpu/rasp-cpu/src/main/java/net/emustudio/plugins/cpu/rasp/gui/RaspStatusPanel.java
@@ -28,16 +28,18 @@ public class RaspStatusPanel extends JPanel {
         cpu.addCPUListener(new CPU.CPUListener() {
             @Override
             public void runStateChanged(CPU.RunState state) {
-                lblStatus.setText(state.toString());
+                SwingUtilities.invokeLater(() -> lblStatus.setText(state.toString()));
             }
 
             @Override
             public void internalStateChanged() {
-                txtR0.setText(String.valueOf(cpu.getACC()));
-                txtIP.setText(String.format("%04d", cpu.getInstructionLocation()));
-                txtInput.setText(input.getSymbolAt(input.getHeadPosition()).map(TapeSymbol::toString).orElse("<empty>"));
                 int outputPos = Math.max(0, output.getHeadPosition() - 1);
-                txtOutput.setText(output.getSymbolAt(outputPos).map(TapeSymbol::toString).orElse("<empty>"));
+                SwingUtilities.invokeLater(() -> {
+                    txtR0.setText(String.valueOf(cpu.getACC()));
+                    txtIP.setText(String.format("%04d", cpu.getInstructionLocation()));
+                    txtInput.setText(input.getSymbolAt(input.getHeadPosition()).map(TapeSymbol::toString).orElse("<empty>"));
+                    txtOutput.setText(output.getSymbolAt(outputPos).map(TapeSymbol::toString).orElse("<empty>"));
+                });
             }
         });
     }

--- a/plugins/cpu/ssem-cpu/src/main/java/net/emustudio/plugins/cpu/ssem/gui/CpuPanel.java
+++ b/plugins/cpu/ssem-cpu/src/main/java/net/emustudio/plugins/cpu/ssem/gui/CpuPanel.java
@@ -98,47 +98,49 @@ public class CpuPanel extends JPanel {
 
         @Override
         public void runStateChanged(CPU.RunState rs) {
-            lblRunState.setText(rs.toString().toUpperCase());
+            SwingUtilities.invokeLater(() -> lblRunState.setText(rs.toString().toUpperCase()));
         }
 
         @Override
         public void internalStateChanged() {
-            int acc = engine.Acc.get();
-            int ci = engine.CI.get();
+            SwingUtilities.invokeLater(() -> {
+                int acc = engine.Acc.get();
+                int ci = engine.CI.get();
 
-            txtA.setText(String.format("%08x", acc));
-            txtDecA.setText(String.format("%d", acc));
-            txtCI.setText(String.format("%08x", ci / 4));
-            txtDecCI.setText(String.format("%d", ci / 4));
-            txtBinA.setText(formatBinary(acc));
-            txtBinCI.setText(formatBinary(ci));
+                txtA.setText(String.format("%08x", acc));
+                txtDecA.setText(String.format("%d", acc));
+                txtCI.setText(String.format("%08x", ci / 4));
+                txtDecCI.setText(String.format("%d", ci / 4));
+                txtBinA.setText(formatBinary(acc));
+                txtBinCI.setText(formatBinary(ci));
 
-            try {
-                Byte[] mCI = memory.read(ci, 4);
-                byte line = (byte) NumberUtils.reverseBits(mCI[0] & 0b11111000, 8);
-                Byte[] mLine = memory.read(line * 4, 4);
+                try {
+                    Byte[] mCI = memory.read(ci, 4);
+                    byte line = (byte) NumberUtils.reverseBits(mCI[0] & 0b11111000, 8);
+                    Byte[] mLine = memory.read(line * 4, 4);
 
-                txtMCI.setText(String.format("%08x", NumberUtils.readInt(mCI, NumberUtils.Strategy.REVERSE_BITS)));
-                txtLine.setText(String.format("%02x", line));
-                txtMLine.setText(String.format("%08x", NumberUtils.readInt(mLine, NumberUtils.Strategy.REVERSE_BITS)));
+                    txtMCI.setText(String.format("%08x", NumberUtils.readInt(mCI, NumberUtils.Strategy.REVERSE_BITS)));
+                    txtLine.setText(String.format("%02x", line));
+                    txtMLine.setText(String.format("%08x", NumberUtils.readInt(mLine, NumberUtils.Strategy.REVERSE_BITS)));
 
-                txtDecMCI.setText(String.format("%d", NumberUtils.readInt(mCI, NumberUtils.Strategy.REVERSE_BITS)));
-                txtDecLine.setText(String.format("%d", line));
-                txtDecMLine.setText(String.format("%d", NumberUtils.readInt(mLine, NumberUtils.Strategy.REVERSE_BITS)));
+                    txtDecMCI.setText(String.format("%d", NumberUtils.readInt(mCI, NumberUtils.Strategy.REVERSE_BITS)));
+                    txtDecLine.setText(String.format("%d", line));
+                    txtDecMLine.setText(String.format("%d", NumberUtils.readInt(mLine, NumberUtils.Strategy.REVERSE_BITS)));
 
-                txtBinMCI.setText(formatBinary(NumberUtils.readInt(mCI, NumberUtils.Strategy.BIG_ENDIAN)));
-                txtBinLine.setText(formatBinary(line, 8));
-                txtBinMLine.setText(formatBinary(NumberUtils.readInt(mLine, NumberUtils.Strategy.BIG_ENDIAN)));
-            } catch (IndexOutOfBoundsException e) {
-                txtLine.setText("?");
-                txtDecLine.setText("?");
-                txtMCI.setText("?");
-                txtDecMCI.setText("?");
-                txtMLine.setText("?");
-                txtDecMLine.setText("?");
-                txtBinMCI.setText("?");
-                txtBinMLine.setText("?");
-            }
+                    txtBinMCI.setText(formatBinary(NumberUtils.readInt(mCI, NumberUtils.Strategy.BIG_ENDIAN)));
+                    txtBinLine.setText(formatBinary(line, 8));
+                    txtBinMLine.setText(formatBinary(NumberUtils.readInt(mLine, NumberUtils.Strategy.BIG_ENDIAN)));
+                } catch (IndexOutOfBoundsException e) {
+                    txtLine.setText("?");
+                    txtDecLine.setText("?");
+                    txtMCI.setText("?");
+                    txtDecMCI.setText("?");
+                    txtMLine.setText("?");
+                    txtDecMLine.setText("?");
+                    txtBinMCI.setText("?");
+                    txtBinMLine.setText("?");
+                }
+            });
         }
 
         private String formatBinary(int number) {

--- a/plugins/cpu/z80-cpu/src/main/java/net/emustudio/plugins/cpu/zilogZ80/gui/StatusPanel.java
+++ b/plugins/cpu/z80-cpu/src/main/java/net/emustudio/plugins/cpu/zilogZ80/gui/StatusPanel.java
@@ -97,7 +97,9 @@ public class StatusPanel extends JPanel {
             }
 
         });
-        cpu.getFrequencyCalculator().addListener(f -> lblFrequency.setText(String.format("%.2f kHz", f)));
+        cpu.getFrequencyCalculator().addListener(
+                f -> SwingUtilities.invokeLater(() -> lblFrequency.setText(String.format("%.2f kHz", f)))
+        );
         spnFrequency.addChangeListener(e -> {
             int i = (Integer) spnFrequency.getModel().getValue();
             try {
@@ -117,41 +119,43 @@ public class StatusPanel extends JPanel {
     }
 
     public void updateGUI() {
-        EmulatorEngine engine = cpu.getEngine();
-        txtA1.setText(byteHex(engine.regs[EmulatorEngine.REG_A]));
-        txtF1.setText(byteHex(engine.flags));
-        txtB1.setText(byteHex(engine.regs[EmulatorEngine.REG_B]));
-        txtC1.setText(byteHex(engine.regs[EmulatorEngine.REG_C]));
-        txtBC1.setText(wordHex(engine.regs[EmulatorEngine.REG_B], engine.regs[EmulatorEngine.REG_C]));
-        txtD1.setText(byteHex(engine.regs[EmulatorEngine.REG_D]));
-        txtE1.setText(byteHex(engine.regs[EmulatorEngine.REG_E]));
-        txtDE1.setText(wordHex(engine.regs[EmulatorEngine.REG_D], engine.regs[EmulatorEngine.REG_E]));
-        txtH1.setText(byteHex(engine.regs[EmulatorEngine.REG_H]));
-        txtL1.setText(byteHex(engine.regs[EmulatorEngine.REG_L]));
-        txtHL1.setText(wordHex(engine.regs[EmulatorEngine.REG_H], engine.regs[EmulatorEngine.REG_L]));
-        flagModel1.fireTableDataChanged();
-        txtA2.setText(byteHex(engine.regs2[EmulatorEngine.REG_A]));
-        txtF2.setText(byteHex(engine.flags2));
-        txtB2.setText(byteHex(engine.regs2[EmulatorEngine.REG_B]));
-        txtC2.setText(byteHex(engine.regs2[EmulatorEngine.REG_C]));
-        txtBC2.setText(wordHex(engine.regs2[EmulatorEngine.REG_B], engine.regs2[EmulatorEngine.REG_C]));
-        txtD2.setText(byteHex(engine.regs2[EmulatorEngine.REG_D]));
-        txtE2.setText(byteHex(engine.regs2[EmulatorEngine.REG_E]));
-        txtDE2.setText(wordHex(engine.regs2[EmulatorEngine.REG_D], engine.regs2[EmulatorEngine.REG_E]));
-        txtH2.setText(byteHex(engine.regs2[EmulatorEngine.REG_H]));
-        txtL2.setText(byteHex(engine.regs2[EmulatorEngine.REG_L]));
-        txtHL2.setText(wordHex(engine.regs2[EmulatorEngine.REG_H], engine.regs2[EmulatorEngine.REG_L]));
-        flagModel2.fireTableDataChanged();
+        SwingUtilities.invokeLater(() -> {
+            EmulatorEngine engine = cpu.getEngine();
+            txtA1.setText(byteHex(engine.regs[EmulatorEngine.REG_A]));
+            txtF1.setText(byteHex(engine.flags));
+            txtB1.setText(byteHex(engine.regs[EmulatorEngine.REG_B]));
+            txtC1.setText(byteHex(engine.regs[EmulatorEngine.REG_C]));
+            txtBC1.setText(wordHex(engine.regs[EmulatorEngine.REG_B], engine.regs[EmulatorEngine.REG_C]));
+            txtD1.setText(byteHex(engine.regs[EmulatorEngine.REG_D]));
+            txtE1.setText(byteHex(engine.regs[EmulatorEngine.REG_E]));
+            txtDE1.setText(wordHex(engine.regs[EmulatorEngine.REG_D], engine.regs[EmulatorEngine.REG_E]));
+            txtH1.setText(byteHex(engine.regs[EmulatorEngine.REG_H]));
+            txtL1.setText(byteHex(engine.regs[EmulatorEngine.REG_L]));
+            txtHL1.setText(wordHex(engine.regs[EmulatorEngine.REG_H], engine.regs[EmulatorEngine.REG_L]));
+            flagModel1.fireTableDataChanged();
+            txtA2.setText(byteHex(engine.regs2[EmulatorEngine.REG_A]));
+            txtF2.setText(byteHex(engine.flags2));
+            txtB2.setText(byteHex(engine.regs2[EmulatorEngine.REG_B]));
+            txtC2.setText(byteHex(engine.regs2[EmulatorEngine.REG_C]));
+            txtBC2.setText(wordHex(engine.regs2[EmulatorEngine.REG_B], engine.regs2[EmulatorEngine.REG_C]));
+            txtD2.setText(byteHex(engine.regs2[EmulatorEngine.REG_D]));
+            txtE2.setText(byteHex(engine.regs2[EmulatorEngine.REG_E]));
+            txtDE2.setText(wordHex(engine.regs2[EmulatorEngine.REG_D], engine.regs2[EmulatorEngine.REG_E]));
+            txtH2.setText(byteHex(engine.regs2[EmulatorEngine.REG_H]));
+            txtL2.setText(byteHex(engine.regs2[EmulatorEngine.REG_L]));
+            txtHL2.setText(wordHex(engine.regs2[EmulatorEngine.REG_H], engine.regs2[EmulatorEngine.REG_L]));
+            flagModel2.fireTableDataChanged();
 
-        txtSP.setText(formatWordHexString(engine.SP));
-        txtPC.setText(formatWordHexString(engine.PC));
-        txtIX.setText(formatWordHexString(engine.IX));
-        txtIY.setText(formatWordHexString(engine.IY));
-        txtI.setText(formatByteHexString(engine.I));
-        txtR.setText(formatByteHexString(engine.R));
+            txtSP.setText(formatWordHexString(engine.SP));
+            txtPC.setText(formatWordHexString(engine.PC));
+            txtIX.setText(formatWordHexString(engine.IX));
+            txtIY.setText(formatWordHexString(engine.IY));
+            txtI.setText(formatByteHexString(engine.I));
+            txtR.setText(formatByteHexString(engine.R));
 
-        lblRunState.setText(runState.toString());
-        spnFrequency.setEnabled(runState != CPU.RunState.STATE_RUNNING);
+            lblRunState.setText(runState.toString());
+            spnFrequency.setEnabled(runState != CPU.RunState.STATE_RUNNING);
+        });
     }
 
     private void initComponents() {

--- a/plugins/device/audio-ay3_8910-chip/src/main/java/net/emustudio/plugins/device/ay38910/Ay38910Chip.java
+++ b/plugins/device/audio-ay3_8910-chip/src/main/java/net/emustudio/plugins/device/ay38910/Ay38910Chip.java
@@ -76,7 +76,7 @@ public class Ay38910Chip implements Context8080.CpuPortDevice, CPUContext.Passed
 
     public Ay38910Chip(AudioSink sink, int sampleRate, IntSupplier cpuFrequencyKHzSupplier) {
         this.cpuFrequencyKHzSupplier = Objects.requireNonNull(cpuFrequencyKHzSupplier);
-        this.currentCpuClockHz = cpuFrequencyKHzSupplier.getAsInt();
+        this.currentCpuClockHz = readCpuClockHz();
         if (sampleRate <= 0) {
             throw new IllegalArgumentException("Sample rate must be > 0");
         }
@@ -86,9 +86,16 @@ public class Ay38910Chip implements Context8080.CpuPortDevice, CPUContext.Passed
         reset();
     }
 
+    private int readCpuClockHz() {
+        // CPUContext#getCPUFrequency() reports kHz; the resampler needs Hz to match the sample rate.
+        return Math.max(1, cpuFrequencyKHzSupplier.getAsInt()) * 1000;
+    }
+
     @Override
     public synchronized byte read(int portAddress) {
-        if (portAddress == DATA_PORT) {
+        // On ZX Spectrum wiring the selected register is read back from the address/latch port (0xFFFD),
+        // while 0xBFFD is write-only for register data.
+        if (portAddress == SELECT_REGISTER_PORT) {
             return (byte) registers[selectedRegister];
         }
         return (byte) 0xFF;
@@ -157,7 +164,7 @@ public class Ay38910Chip implements Context8080.CpuPortDevice, CPUContext.Passed
         waveformBufferFilled = false;
         sampleBuffer.clear();
         primarySink.flushAudio();
-        this.currentCpuClockHz = cpuFrequencyKHzSupplier.getAsInt();
+        this.currentCpuClockHz = readCpuClockHz();
     }
 
     public synchronized int getVolumePercent() {
@@ -232,7 +239,10 @@ public class Ay38910Chip implements Context8080.CpuPortDevice, CPUContext.Passed
     }
 
     private void advanceEnvelope(long cpuCycles) {
-        long stepPeriod = 512L * Math.max(1, envelopePeriod());
+        // fE = clock / (256 * EP) for a full 16-step ramp, so one step takes 16*EP chip clocks.
+        // The chip is clocked at half the CPU rate (matching the 16*TP tone / 32*NP noise scaling),
+        // hence 32*EP CPU cycles per envelope step.
+        long stepPeriod = 32L * Math.max(1, envelopePeriod());
         envelopeCounter += cpuCycles;
         long steps = envelopeCounter / stepPeriod;
         if (steps == 0) {

--- a/plugins/device/audio-ay3_8910-chip/src/test/java/net/emustudio/plugins/device/ay38910/Ay38910ChipTest.java
+++ b/plugins/device/audio-ay3_8910-chip/src/test/java/net/emustudio/plugins/device/ay38910/Ay38910ChipTest.java
@@ -10,7 +10,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class Ay38910ChipTest {
-    private static final int CPU_CLOCK_HZ = 3_500_000;
+    private static final int CPU_CLOCK_KHZ = 3_500;
+    private static final int CPU_CLOCK_HZ = CPU_CLOCK_KHZ * 1000;
 
     @Test
     public void testRegisterWritesAreMaskedAndReadable() {
@@ -20,13 +21,15 @@ public class Ay38910ChipTest {
         chip.write(Ay38910Chip.DATA_PORT, (byte) 0xFF);
 
         chip.write(Ay38910Chip.SELECT_REGISTER_PORT, (byte) 0x01);
-        assertEquals(0x0F, chip.read(Ay38910Chip.DATA_PORT) & 0xFF);
+        assertEquals(0x0F, chip.read(Ay38910Chip.SELECT_REGISTER_PORT) & 0xFF);
+        // The data port (0xBFFD) is write-only; reading it must not return the register value.
+        assertEquals(0xFF, chip.read(Ay38910Chip.DATA_PORT) & 0xFF);
     }
 
     @Test
     public void testToneGenerationProducesPositiveAndNegativeSamples() {
         RecordingAudioSink sink = new RecordingAudioSink();
-        Ay38910Chip chip = new Ay38910Chip(sink, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_HZ);
+        Ay38910Chip chip = new Ay38910Chip(sink, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_KHZ);
 
         writeRegister(chip, 0, 0x20);
         writeRegister(chip, 1, 0x00);
@@ -42,16 +45,34 @@ public class Ay38910ChipTest {
     }
 
     @Test
+    public void testSampleRateMatchesConfiguredOutputRate() {
+        RecordingAudioSink sink = new RecordingAudioSink();
+        Ay38910Chip chip = new Ay38910Chip(sink, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_KHZ);
+
+        writeRegister(chip, 0, 0x20);
+        writeRegister(chip, 7, 0b00111000);
+        writeRegister(chip, 8, 0x0F);
+
+        chip.passedCycles(CPU_CLOCK_HZ); // exactly one second of CPU cycles
+        chip.close();
+
+        int frames = sink.toShortArray().length / Ay38910Chip.CHANNELS;
+        int expected = Ay38910Chip.DEFAULT_SAMPLE_RATE;
+        assertTrue("Expected ~" + expected + " frames for one second but got " + frames,
+                Math.abs(frames - expected) <= expected / 100);
+    }
+
+    @Test
     public void testEnvelopeModeChangesAmplitudeOverTime() {
         RecordingAudioSink sink = new RecordingAudioSink();
-        Ay38910Chip chip = new Ay38910Chip(sink, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_HZ);
+        Ay38910Chip chip = new Ay38910Chip(sink, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_KHZ);
 
         writeRegister(chip, 0, 0x10);
         writeRegister(chip, 1, 0x00);
         writeRegister(chip, 7, 0b00111000);
         writeRegister(chip, 8, 0x10);
-        writeRegister(chip, 11, 0x01);
-        writeRegister(chip, 12, 0x00);
+        writeRegister(chip, 11, 0x00);
+        writeRegister(chip, 12, 0x06);
         writeRegister(chip, 13, 0x0D);
 
         chip.passedCycles(CPU_CLOCK_HZ / 5);
@@ -87,7 +108,7 @@ public class Ay38910ChipTest {
     }
 
     private static Ay38910Chip silentChip() {
-        return new Ay38910Chip(AudioSink.NULL, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_HZ);
+        return new Ay38910Chip(AudioSink.NULL, Ay38910Chip.DEFAULT_SAMPLE_RATE, () -> CPU_CLOCK_KHZ);
     }
 
     private static boolean hasPositive(short[] samples) {

--- a/plugins/memory/byte-mem/src/main/java/net/emustudio/plugins/memory/bytemem/MemoryContextImpl.java
+++ b/plugins/memory/byte-mem/src/main/java/net/emustudio/plugins/memory/bytemem/MemoryContextImpl.java
@@ -17,9 +17,9 @@ public class MemoryContextImpl extends AbstractMemoryContext<Byte> implements By
 
     private final RangeTree romRanges = new RangeTree();
     private final MemoryContextAnnotations annotations;
-    private Byte[][] mem = new Byte[1][0];
+    private volatile Byte[][] mem = new Byte[1][0];
     private int banksCount;
-    private int bankSelect = 0;
+    private volatile int bankSelect = 0;
     private int bankCommon = 0;
 
     protected MemoryContextImpl(MemoryContextAnnotations annotations) {


### PR DESCRIPTION
## Overview

Primarily remediates findings from a full architecture & implementation review of the runtime and plugin platform (tracked in #406): fixes correctness bugs in the headless/automation path, tightens module boundaries and plugin lifecycle, pins the build toolchain, and bootstraps `docs/adr`.

Two smaller, pre-existing commits ride along on this branch — see **Also included** below.

## [#406] Architecture review remediation

### Bug fixes (correctness)
- **Headless automation NPE (High).** `ApplicationApiImpl` no longer rejects a null GUI (`this.gui = gui`), matching the plugin contract where CPU plugins already guard on `getGUI() == null`. Fixes `NullPointerException` in `automation --no-gui`.
- **CLI subcommand dispatch (High).** `Runner` now implements `Callable<Integer>` with a single picocli execution (`executeArgs`/`normalizeArgs`), removing the double-parse + `runsSomeCommand` flag that made inherited options placed *after* the `automation` subcommand silently launch the GUI. Also removes scattered `System.exit`.
- **Lost-notification hang (High).** `Automation` guards `resultStateLock.wait()` with a state predicate so a fast-halting program cannot notify before the wait and hang forever.

### Boundaries & lifecycle
- **Plugin lifecycle (Medium).** `VirtualComputer.close()` destroys plugins in reverse init order (devices → CPU → memory → compiler), idempotently, then owns and **closes the plugin `URLClassLoader`**, then closes config.
- **Runtime → GUI boundary (Medium).** New `EmulationProgress` port (with `NONE` no-op); `Automation` no longer imports `gui.dialogs.AutoDialog`, which now implements the port.
- **EDT safety (Medium).** CPU status panels marshal Swing updates onto the EDT (`8080`, `brainduck`, `ram`, `rasp`, `ssem`, `z80`).
- **byte-mem visibility (Low).** Memory/bank fields made `volatile`.

### Build & docs
- **Toolchain pin (Medium).** Java toolchain pinned to `JavaLanguageVersion.of(11)`.
- **Release snapshot guard (Medium).** New `checkNoSnapshots` + `releaseDist` Gradle tasks fail release packaging on any `-SNAPSHOT` dependency.
- **ADRs (Low).** New `docs/adr/` with ADR-0001…0007 (ADR process, plugin-loading contract, context interface hashing, project format, headless mode, plugin lifecycle & classloader ownership, automation-progress UI boundary). `docs/code.adoc` / `docs/components.adoc` aligned re: context registration.

### Tests
New `AutomationBoundaryTest`; updated `AutomationTest`, `RunnerTest`, `AutomationCommandTest`, `ApplicationApiImplTest`, `VirtualComputerTest` (destroy order + classloader close), `PluginLoaderTest`.

## Also included (separate commits on this branch)
- **[#398]** Fix AY-3-8910 clock units, read port, envelope (`Ay38910Chip.java` + test).
- **Update AGENTS.md** — repo conventions/documentation refresh.

## Testing
- `./gradlew build`
- Manual: `emuStudio -cn BrainDuck automation --no-gui -w 800` completes without NPE.

## Notes
- Out of scope / follow-ups: 8080 hot-path allocations; `EMUSTUDIO_ID` reconciliation; positional plugin/config pairing; `trustedPlugin` rename; emuLib-side items (`CPUWatchTask` interrupt notify, `getGUI()` nullability javadoc).
- Branch is named `feature-314`, but issue #314 is unrelated ("Implement ZX Spectrum 48K"); the remediation work is tracked under #406.

Closes #406
